### PR TITLE
fix: add session locking to prevent concurrent request interference

### DIFF
--- a/tests/unit/test_session_locking.py
+++ b/tests/unit/test_session_locking.py
@@ -214,6 +214,7 @@ class TestSessionLockIntegration:
         This tests the actual integration with flaresolverr_service.
         """
         from dtos import V1RequestBase
+        from unittest.mock import MagicMock
 
         # Mock the webdriver creation
         monkeypatch.setattr(
@@ -226,21 +227,30 @@ class TestSessionLockIntegration:
         storage = sessions.SessionsStorage()
         session, _ = storage.create("integration-test")
 
-        # Track lock usage
+        # Track lock usage by wrapping the lock with MagicMock
         lock_acquisitions = []
-        original_acquire = session.lock.acquire
-        original_release = session.lock.release
+        original_lock = session.lock
 
-        def tracking_acquire(*args, **kwargs):
-            lock_acquisitions.append("acquire")
-            return original_acquire(*args, **kwargs)
+        # Create a wrapper that tracks calls
+        class LockWrapper:
+            def __init__(self, real_lock):
+                self._lock = real_lock
+                self.acquired = False
 
-        def tracking_release():
-            lock_acquisitions.append("release")
-            original_release()
+            def acquire(self, blocking=True, timeout=-1):
+                lock_acquisitions.append("acquire")
+                self.acquired = True
+                return self._lock.acquire(blocking, timeout)
 
-        session.lock.acquire = tracking_acquire
-        session.lock.release = tracking_release
+            def release(self):
+                lock_acquisitions.append("release")
+                self.acquired = False
+                self._lock.release()
+
+            def locked(self):
+                return self._lock.locked()
+
+        session.lock = LockWrapper(original_lock)
 
         # Create request with session
         req = V1RequestBase({


### PR DESCRIPTION
## Description

This PR fixes the concurrent request issue where multiple requests using the same session can interfere with each other, causing both to receive the same (incorrect) response.

### The Problem

When a FlareSolverr session reuses a single WebDriver instance, concurrent requests that specify the same session can overlap and interfere with each other. If request A is still being processed and request B starts using the same session/WebDriver, B can receive A's response.

### The Solution

Added a `threading.Lock` to each Session object that is acquired when a request starts using a session and released when the request completes (or fails). This ensures:

1. Only one request can use a WebDriver session at a time
2. Subsequent requests to the same session will wait until the current one completes
3. Proper cleanup happens even if the request fails

### Changes

- `src/sessions.py`: Added `lock: threading.Lock` field to `Session` class with initialization in `__init__`
- `src/flaresolverr_service.py`: Added lock acquisition/release in `_resolve_challenge()` with debug logging

### References

Upstream issue: https://github.com/FlareSolverr/FlareSolverr/issues/1685