### PR TITLE
fix(security): add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -17,6 +17,9 @@ jobs:
   build-docker-images:
     if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -90,6 +93,9 @@ jobs:
           retention-days: 1
 
   merge:
+    permissions:
+      contents: read
+      packages: write
     if: ${{ !github.event.pull_request.head.repo.fork && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     needs: build-docker-images

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   create-release:
     name: Create release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -34,6 +36,8 @@ jobs:
     name: Build binaries
     needs: create-release
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]


### PR DESCRIPTION
This PR addresses CodeQL security alerts by adding explicit permissions to GitHub Actions workflows.

## Changes

- **release.yml**: Added `permissions: contents: write` to both jobs (required for creating releases and uploading artifacts)
- **release-docker.yml**: Added `permissions: contents: read, packages: write` to both jobs (required for reading repo and pushing to GHCR)

## Security Alerts Fixed

- Alert #3: Workflow does not contain permissions (release.yml)
- Alert #4: Workflow does not contain permissions (release.yml)
- Alert #14: Workflow does not contain permissions (release-docker.yml)
- Alert #15: Workflow does not contain permissions (release-docker.yml)

## Notes

- Alert #6 was dismissed as false positive - the proxy credentials need to be in clear text for the Chrome extension to authenticate with the proxy server. The temp file is immediately cleaned up.

These changes follow the principle of least privilege by explicitly declaring required permissions rather than relying on repository defaults.