### PR TITLE
Restore download option with binary content support (#37)

### DIFF
--- a/src/flaresolverr/dtos.py
+++ b/src/flaresolverr/dtos.py
@@ -13,6 +13,7 @@ class ChallengeResolutionResultT:
     userAgent: str | None = None
     screenshot: str | None = None  # noqa
     turnstile_token: str | None = None
+    isBinary: bool | None = None
     # Session interaction results
     evalResult: Any | None = None
     networkLogs: list[dict[str, Any]] | None = None
@@ -54,7 +55,7 @@ class V1RequestBase(object):
     postData: str | None = None
     returnOnlyCookies: bool | None = None
     returnScreenshot: bool | None = None
-    download: bool | None = None  # deprecated v2.0.0, not used
+    download: bool | None = None
     returnRawHtml: bool | None = None  # deprecated v2.0.0, not used
     waitInSeconds: int | None = None
     # Session interaction commands

--- a/src/flaresolverr/flaresolverr_service.py
+++ b/src/flaresolverr/flaresolverr_service.py
@@ -231,8 +231,6 @@ def _validate_common_request_params(req: V1RequestBase) -> None:
     """Validate request parameters shared between GET and POST commands."""
     if req.returnRawHtml is not None:
         logging.warning("Request parameter 'returnRawHtml' was removed in FlareSolverr v2.")
-    if req.download is not None:
-        logging.warning("Request parameter 'download' was removed in FlareSolverr v2.")
     if req.captchaSolver is not None:
         available = get_available_solvers()
         if req.captchaSolver not in available:
@@ -875,6 +873,62 @@ def _execute_actions(driver: WebDriver, actions: list) -> list[Any | None]:
     return eval_results
 
 
+def _get_download_content(driver: WebDriver, url: str) -> tuple[str, bool, dict[str, str] | None]:
+    """Get raw page content for download mode.
+
+    Tries CDP Page.getResourceContent first, then falls back to a JS fetch.
+    Returns (content, is_binary, headers_dict_or_none).
+    """
+    # Try CDP Page.getResourceContent first
+    try:
+        driver.execute_cdp_cmd("Page.enable", {})
+        resource = driver.execute_cdp_cmd("Page.getResourceContent", {"url": url})
+        content = resource.get("content", "")
+        is_base64 = resource.get("base64Encoded", False)
+        if is_base64:
+            return content, True, None
+        return content, False, None
+    except Exception as e:
+        logging.debug(f"Page.getResourceContent failed: {e}")
+
+    # Fallback: JS fetch with FileReader data URL
+    script = """
+        return fetch(arguments[0], {credentials: 'include'})
+            .then(r => r.blob())
+            .then(blob => new Promise((resolve, reject) => {
+                const reader = new FileReader();
+                reader.onloadend = () => resolve({
+                    dataUrl: reader.result,
+                    type: blob.type,
+                    size: blob.size
+                });
+                reader.onerror = reject;
+                reader.readAsDataURL(blob);
+            }));
+    """
+    try:
+        result = driver.execute_script(script, url)
+        data_url = result.get("dataUrl", "")
+        content_type = result.get("type", "")
+        size = result.get("size", 0)
+        if data_url.startswith("data:"):
+            comma_idx = data_url.index(",")
+            content = data_url[comma_idx + 1:]
+            is_binary = utils.is_binary_content_type(content_type)
+            headers: dict[str, str] | None = {}
+            if content_type:
+                headers["Content-Type"] = content_type
+            if size:
+                headers["Content-Length"] = str(size)
+            return content, is_binary, headers
+    except Exception as e:
+        logging.debug(f"JS fetch fallback failed: {e}")
+
+    # Ultimate fallback: page_source
+    page_source = _safe_driver_call(lambda: driver.page_source, "")
+    return page_source or "", False, None
+
+
 def _build_challenge_result(req: V1RequestBase, driver: WebDriver, turnstile_token: str | None) -> ChallengeResolutionResultT:
     challenge_res = ChallengeResolutionResultT({})
     challenge_res.url = driver.current_url
@@ -895,7 +949,14 @@ def _build_challenge_result(req: V1RequestBase, driver: WebDriver, turnstile_tok
             logging.info("Waiting " + str(req.waitInSeconds) + " seconds before returning the response...")
             time.sleep(req.waitInSeconds)
 
-        challenge_res.response = driver.page_source
+        if req.download:
+            content, is_binary, download_headers = _get_download_content(driver, driver.current_url)
+            challenge_res.response = content
+            challenge_res.isBinary = is_binary
+            if download_headers:
+                challenge_res.headers = download_headers
+        else:
+            challenge_res.response = driver.page_source
 
     # Get cookies after waiting to ensure all challenge cookies are captured
     challenge_res.cookies = driver.get_cookies()

--- a/src/flaresolverr/flaresolverr_service.py
+++ b/src/flaresolverr/flaresolverr_service.py
@@ -913,7 +913,7 @@ def _get_download_content(driver: WebDriver, url: str) -> tuple[str, bool, dict[
         size = result.get("size", 0)
         if data_url.startswith("data:"):
             comma_idx = data_url.index(",")
-            content = data_url[comma_idx + 1:]
+            content = data_url[comma_idx + 1 :]
             is_binary = utils.is_binary_content_type(content_type)
             headers: dict[str, str] | None = {}
             if content_type:

--- a/src/flaresolverr/utils.py
+++ b/src/flaresolverr/utils.py
@@ -42,6 +42,23 @@ STEALTH_MODE_STANDARD = "standard"
 STEALTH_MODE_CSP_SAFE = "csp-safe"
 VALID_STEALTH_MODES = {STEALTH_MODE_OFF, STEALTH_MODE_STANDARD, STEALTH_MODE_CSP_SAFE}
 
+_TEXT_CONTENT_PREFIXES = (
+    "text/",
+    "application/json",
+    "application/javascript",
+    "application/xml",
+    "application/xhtml+xml",
+    "application/ld+json",
+)
+
+
+def is_binary_content_type(content_type: str | None) -> bool:
+    """Return True if the content-type indicates binary data."""
+    if not content_type:
+        return True
+    ct = content_type.lower()
+    return not ct.startswith(_TEXT_CONTENT_PREFIXES)
+
 
 def _load_stealth_script(fallback: bool = False) -> str:
     global _STEALTH_SCRIPT, _STEALTH_FALLBACK_SCRIPT

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -1,0 +1,250 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("func_timeout")
+from flaresolverr.dtos import ChallengeResolutionResultT, V1RequestBase
+from flaresolverr.flaresolverr_service import _build_challenge_result, _get_download_content
+
+
+class FakeDriver:
+    def __init__(self, current_url="https://example.com/image.jpg", page_source="<html></html>"):
+        self._current_url = current_url
+        self._page_source = page_source
+        self._cookies = [{"name": "test", "value": "cookie"}]
+        self._screenshot = "base64screenshot"
+        self._calls = []
+
+    @property
+    def current_url(self):
+        return self._current_url
+
+    @property
+    def page_source(self):
+        return self._page_source
+
+    def get_cookies(self):
+        return self._cookies
+
+    def get_screenshot_as_base64(self):
+        return self._screenshot
+
+    def execute_cdp_cmd(self, cmd, params=None):
+        self._calls.append(("execute_cdp_cmd", cmd, params))
+        return {}
+
+    def execute_script(self, script, *args):
+        self._calls.append(("execute_script", script, args))
+        return {}
+
+
+def _make_req(download=False, return_only_cookies=False):
+    req = V1RequestBase({"cmd": "request.get", "url": "https://example.com/image.jpg"})
+    req.download = download
+    req.returnOnlyCookies = return_only_cookies
+    req.actions = None
+    req.waitInSeconds = None
+    req.returnScreenshot = False
+    return req
+
+
+def test_build_challenge_result_without_download_uses_page_source(monkeypatch):
+    driver = FakeDriver(page_source="<html><body>hello</body></html>")
+    req = _make_req(download=False)
+
+    monkeypatch.setattr(
+        "flaresolverr.flaresolverr_service.utils.get_user_agent",
+        lambda _driver: "TestUA",
+    )
+
+    result = _build_challenge_result(req, driver, None)
+
+    assert isinstance(result, ChallengeResolutionResultT)
+    assert result.response == "<html><body>hello</body></html>"
+    assert result.isBinary is None
+    assert result.url == "https://example.com/image.jpg"
+    assert len(driver._calls) == 0
+
+
+def test_build_challenge_result_with_download_cdp_base64(monkeypatch):
+    driver = FakeDriver()
+
+    def fake_execute_cdp_cmd(cmd, params=None):
+        driver._calls.append(("execute_cdp_cmd", cmd, params))
+        if cmd == "Page.enable":
+            return {}
+        if cmd == "Page.getResourceContent":
+            return {"content": "aGVsbG8=", "base64Encoded": True}
+        return {}
+
+    driver.execute_cdp_cmd = fake_execute_cdp_cmd
+    req = _make_req(download=True)
+
+    monkeypatch.setattr(
+        "flaresolverr.flaresolverr_service.utils.get_user_agent",
+        lambda _driver: "TestUA",
+    )
+
+    result = _build_challenge_result(req, driver, None)
+
+    assert result.response == "aGVsbG8="
+    assert result.isBinary is True
+    assert any(c[1] == "Page.getResourceContent" for c in driver._calls)
+
+
+def test_build_challenge_result_with_download_cdp_text(monkeypatch):
+    driver = FakeDriver()
+
+    def fake_execute_cdp_cmd(cmd, params=None):
+        driver._calls.append(("execute_cdp_cmd", cmd, params))
+        if cmd == "Page.enable":
+            return {}
+        if cmd == "Page.getResourceContent":
+            return {"content": "plain text", "base64Encoded": False}
+        return {}
+
+    driver.execute_cdp_cmd = fake_execute_cdp_cmd
+    req = _make_req(download=True)
+
+    monkeypatch.setattr(
+        "flaresolverr.flaresolverr_service.utils.get_user_agent",
+        lambda _driver: "TestUA",
+    )
+
+    result = _build_challenge_result(req, driver, None)
+
+    assert result.response == "plain text"
+    assert result.isBinary is False
+
+
+def test_build_challenge_result_with_download_js_fallback(monkeypatch):
+    driver = FakeDriver()
+
+    def fake_execute_cdp_cmd(cmd, params=None):
+        driver._calls.append(("execute_cdp_cmd", cmd, params))
+        if cmd == "Page.enable":
+            return {}
+        raise Exception("CDP not available")
+
+    def fake_execute_script(script, *args):
+        driver._calls.append(("execute_script", script, args))
+        return {
+            "dataUrl": "data:image/jpeg;base64,/9j/4AAQ...",
+            "type": "image/jpeg",
+            "size": 12345,
+        }
+
+    driver.execute_cdp_cmd = fake_execute_cdp_cmd
+    driver.execute_script = fake_execute_script
+    req = _make_req(download=True)
+
+    monkeypatch.setattr(
+        "flaresolverr.flaresolverr_service.utils.get_user_agent",
+        lambda _driver: "TestUA",
+    )
+
+    result = _build_challenge_result(req, driver, None)
+
+    assert result.response == "/9j/4AAQ..."
+    assert result.isBinary is True
+    assert result.headers == {"Content-Type": "image/jpeg", "Content-Length": "12345"}
+
+
+def test_build_challenge_result_with_download_fallback_to_page_source(monkeypatch):
+    driver = FakeDriver(page_source="<html><body>fallback</body></html>")
+
+    def fake_execute_cdp_cmd(cmd, params=None):
+        raise Exception("CDP not available")
+
+    def fake_execute_script(script, *args):
+        raise Exception("JS fetch failed")
+
+    driver.execute_cdp_cmd = fake_execute_cdp_cmd
+    driver.execute_script = fake_execute_script
+    req = _make_req(download=True)
+
+    monkeypatch.setattr(
+        "flaresolverr.flaresolverr_service.utils.get_user_agent",
+        lambda _driver: "TestUA",
+    )
+
+    result = _build_challenge_result(req, driver, None)
+
+    assert result.response == "<html><body>fallback</body></html>"
+    assert result.isBinary is False
+
+
+def test_build_challenge_result_return_only_cookies_skips_response(monkeypatch):
+    driver = FakeDriver()
+    req = _make_req(download=True, return_only_cookies=True)
+
+    monkeypatch.setattr(
+        "flaresolverr.flaresolverr_service.utils.get_user_agent",
+        lambda _driver: "TestUA",
+    )
+
+    result = _build_challenge_result(req, driver, None)
+
+    assert result.response is None
+    assert result.cookies == [{"name": "test", "value": "cookie"}]
+    assert len(driver._calls) == 0
+
+
+def test_get_download_content_cdp_text():
+    driver = FakeDriver()
+
+    def fake_execute_cdp_cmd(cmd, params=None):
+        driver._calls.append(("execute_cdp_cmd", cmd, params))
+        if cmd == "Page.enable":
+            return {}
+        if cmd == "Page.getResourceContent":
+            return {"content": "hello world", "base64Encoded": False}
+        return {}
+
+    driver.execute_cdp_cmd = fake_execute_cdp_cmd
+    content, is_binary, headers = _get_download_content(driver, "https://example.com")
+
+    assert content == "hello world"
+    assert is_binary is False
+    assert headers is None
+
+
+def test_get_download_content_js_fetch_text():
+    driver = FakeDriver()
+
+    def fake_execute_cdp_cmd(cmd, params=None):
+        raise Exception("CDP not available")
+
+    def fake_execute_script(script, *args):
+        return {
+            "dataUrl": "data:text/plain;base64,aGVsbG8=",
+            "type": "text/plain",
+            "size": 5,
+        }
+
+    driver.execute_cdp_cmd = fake_execute_cdp_cmd
+    driver.execute_script = fake_execute_script
+    content, is_binary, headers = _get_download_content(driver, "https://example.com")
+
+    assert content == "aGVsbG8="
+    assert is_binary is False
+    assert headers == {"Content-Type": "text/plain", "Content-Length": "5"}
+
+
+def test_get_download_content_page_source_fallback():
+    driver = FakeDriver(page_source="<html></html>")
+
+    def fake_execute_cdp_cmd(cmd, params=None):
+        raise Exception("CDP not available")
+
+    def fake_execute_script(script, *args):
+        raise Exception("JS fetch failed")
+
+    driver.execute_cdp_cmd = fake_execute_cdp_cmd
+    driver.execute_script = fake_execute_script
+    content, is_binary, headers = _get_download_content(driver, "https://example.com")
+
+    assert content == "<html></html>"
+    assert is_binary is False
+    assert headers is None

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,3 +1,5 @@
+import pytest
+
 from flaresolverr import utils
 
 
@@ -10,3 +12,27 @@ def test_sanitize_user_agent_removes_headless_token():
 def test_sanitize_user_agent_keeps_regular_user_agent():
     ua = "Mozilla/5.0 (...) Chrome/147.0.0.0 Safari/537.36"
     assert utils.sanitize_user_agent(ua) == ua
+
+
+@pytest.mark.parametrize(
+    ("content_type", "expected"),
+    [
+        ("text/html", False),
+        ("text/plain", False),
+        ("application/json", False),
+        ("application/javascript", False),
+        ("application/xml", False),
+        ("application/xhtml+xml", False),
+        ("application/ld+json", False),
+        ("image/jpeg", True),
+        ("image/png", True),
+        ("application/pdf", True),
+        ("application/octet-stream", True),
+        ("audio/mpeg", True),
+        ("video/mp4", True),
+        ("", True),
+        (None, True),
+    ],
+)
+def test_is_binary_content_type(content_type, expected):
+    assert utils.is_binary_content_type(content_type) is expected

--- a/whitelist.py
+++ b/whitelist.py
@@ -8,6 +8,7 @@ to static analysis, but are required at runtime.
 from flaresolverr.bottle_plugins import error_plugin, logger_plugin, prometheus_plugin
 from flaresolverr.client.client import _SessionManager
 from flaresolverr.client.models import ChallengeSolution
+from flaresolverr.dtos import ChallengeResolutionResultT
 from flaresolverr.sessions import SessionsStorage
 from selenium.webdriver.chrome.options import Options
 
@@ -24,6 +25,7 @@ _SessionManager.click
 _SessionManager.action
 
 # Model fields populated dynamically from API responses
+ChallengeResolutionResultT.isBinary
 ChallengeSolution.evalResult
 ChallengeSolution.networkLogs
 ChallengeSolution.screenshot


### PR DESCRIPTION
Closes #37

### Problem
The `download` option was removed in v2.0.0 and marked as deprecated. Users could not download binary content like images, PDFs, or other non-HTML resources through FlareSolverr.

### Solution
Restores the `download` functionality for **direct binary URL requests** (`request.get` / `request.post`):
- Detects when the response is binary (non-text) using the `Content-Type` header
- Returns base64-encoded content in the `response` field when `download=true`
- Sets appropriate `Content-Type` and `Content-Length` headers in the result
- Adds an `isBinary` flag to indicate whether the content is binary data

### How it works
When `download=true` is passed in a `request.get` or `request.post` call, `_get_download_content()` tries three strategies in order:
1. **CDP `Page.getResourceContent`** — returns the raw resource directly from the browser's cache. If Chrome already encoded it as base64, we pass that through.
2. **JS `fetch` + `FileReader` fallback** — re-fetches the URL with credentials and reads the response as a data URL. This gives us the MIME type and size for headers.
3. **Ultimate fallback** to `driver.page_source`.

### API response example
```json
{
  "status": "ok",
  "solution": {
    "url": "https://example.com/image.jpg",
    "response": "/9j/4AAQ...",
    "headers": {
      "Content-Type": "image/jpeg",
      "Content-Length": "12345"
    },
    "isBinary": true,
    "cookies": [...]
  }
}
```

### What this does NOT cover
This PR does **not** handle downloads triggered by browser actions (e.g., clicking a "Download" button). When a button click triggers a download, the browser hands the response to its download manager rather than rendering it as a page, so the current mechanism cannot intercept it. See #68 for the follow-up feature request.

### Files changed
- `src/flaresolverr/dtos.py` — added `isBinary` field to `ChallengeResolutionResultT`
- `src/flaresolverr/utils.py` — added `is_binary_content_type()` helper
- `src/flaresolverr/flaresolverr_service.py` — restored `download` handling with `_get_download_content()`
- `tests/unit/test_utils.py` — added `is_binary_content_type` parametric tests
- `tests/unit/test_download.py` — new test module covering all download code paths

### Test results
302 unit tests passed (3 skipped due to missing `prometheus_client` in this environment).