### PR TITLE
Add support for raw and JSON POST data (closes #35)

### DIFF
--- a/API.md
+++ b/API.md
@@ -226,12 +226,17 @@ Example:
 
 ### + `request.post`
 
-This works like `request.get`, with the addition of the `postData` parameter.
+This works like `request.get`, with the addition of the `postData` / `postDataRaw` parameters.
 
 | Parameter | Notes |
 | --------- | ----- |
-| postData | Must be a string with `application/x-www-form-urlencoded`. Eg: `a=b&c=d` |
+| postData | Optional (unless `postDataRaw` is omitted). Must be a string with `application/x-www-form-urlencoded`. Eg: `a=b&c=d` |
+| postDataRaw | Optional (unless `postData` is omitted). Raw body sent without form encoding. Supports JSON, XML, or any custom payload. |
+| postDataContentType | Optional. Content-Type header for `postDataRaw` (default: `application/x-www-form-urlencoded`). |
 | headers | Optional. Same format as `request.get`. |
+
+> **Note**
+> Only one of `postData` or `postDataRaw` can be used in a single request, not both.
 
 ---
 

--- a/src/flaresolverr/client/client.py
+++ b/src/flaresolverr/client/client.py
@@ -319,8 +319,10 @@ class _RequestManager:
     def post(
         self,
         url: str,
-        post_data: str,
+        post_data: str | None = None,
         *,
+        post_data_raw: str | None = None,
+        post_data_content_type: str | None = None,
         session: str | None = None,
         session_ttl_minutes: int | None = None,
         session_max_runtime: int | None = None,
@@ -348,6 +350,8 @@ class _RequestManager:
         Args:
             url: The URL to request (mandatory).
             post_data: Form data as application/x-www-form-urlencoded string (e.g., "a=b&c=d").
+            post_data_raw: Raw body content sent without form encoding.
+            post_data_content_type: Content-Type header for raw body (default: application/x-www-form-urlencoded).
             session: Optional session ID for persistent browser state.
             session_ttl_minutes: Optional TTL for automatic session rotation.
             session_max_runtime: Optional per-session max lifetime in seconds.
@@ -378,6 +382,8 @@ class _RequestManager:
             cmd="request.post",
             url=url,
             post_data=post_data,
+            post_data_raw=post_data_raw,
+            post_data_content_type=post_data_content_type,
             session=session,
             session_ttl_minutes=session_ttl_minutes,
             session_max_runtime=session_max_runtime,
@@ -408,6 +414,8 @@ class _RequestManager:
         cmd: str,
         url: str,
         post_data: str | None = None,
+        post_data_raw: str | None = None,
+        post_data_content_type: str | None = None,
         session: str | None = None,
         session_ttl_minutes: int | None = None,
         session_max_runtime: int | None = None,
@@ -439,6 +447,10 @@ class _RequestManager:
 
         if post_data is not None:
             payload["postData"] = post_data
+        if post_data_raw is not None:
+            payload["postDataRaw"] = post_data_raw
+        if post_data_content_type is not None:
+            payload["postDataContentType"] = post_data_content_type
         if session is not None:
             payload["session"] = session
         if session_ttl_minutes is not None:

--- a/src/flaresolverr/dtos.py
+++ b/src/flaresolverr/dtos.py
@@ -52,6 +52,8 @@ class V1RequestBase(object):
     # V1Request
     url: str | None = None
     postData: str | None = None
+    postDataRaw: str | None = None
+    postDataContentType: str | None = None
     returnOnlyCookies: bool | None = None
     returnScreenshot: bool | None = None
     download: bool | None = None  # deprecated v2.0.0, not used

--- a/src/flaresolverr/flaresolverr_service.py
+++ b/src/flaresolverr/flaresolverr_service.py
@@ -1083,7 +1083,7 @@ def _post_request_raw(req: V1RequestBase, driver: WebDriver) -> None:
                             break
                         # Continue non-matching requests unchanged
                         driver.execute_cdp_cmd("Fetch.continueRequest", {"requestId": paused_id})
-                except Exception:
+                except Exception:  # nosec B112
                     continue
 
             if request_id is not None:
@@ -1129,7 +1129,7 @@ def _post_request_raw(req: V1RequestBase, driver: WebDriver) -> None:
     finally:
         try:
             driver.execute_cdp_cmd("Fetch.disable", {})
-        except Exception:
+        except Exception:  # nosec B110
             pass
 
 

--- a/src/flaresolverr/flaresolverr_service.py
+++ b/src/flaresolverr/flaresolverr_service.py
@@ -1105,12 +1105,15 @@ def _post_request_raw(req: V1RequestBase, driver: WebDriver) -> None:
 
         # Continue the intercepted request as POST with raw body
         post_data_b64 = base64.b64encode(post_data.encode("utf-8")).decode("ascii")
-        driver.execute_cdp_cmd("Fetch.continueRequest", {
-            "requestId": request_id,
-            "method": "POST",
-            "postData": post_data_b64,
-            "headers": headers,
-        })
+        driver.execute_cdp_cmd(
+            "Fetch.continueRequest",
+            {
+                "requestId": request_id,
+                "method": "POST",
+                "postData": post_data_b64,
+                "headers": headers,
+            },
+        )
 
         # Wait for the page to finish loading
         load_timeout = 60

--- a/src/flaresolverr/flaresolverr_service.py
+++ b/src/flaresolverr/flaresolverr_service.py
@@ -252,7 +252,9 @@ def _cmd_request_get(req: V1RequestBase) -> V1ResponseBase:
     if req.url is None:
         raise Exception("Request parameter 'url' is mandatory in 'request.get' command.")
     if req.postData is not None:
-        raise Exception("Cannot use 'postBody' when sending a GET request.")
+        raise Exception("Cannot use 'postData' when sending a GET request.")
+    if req.postDataRaw is not None:
+        raise Exception("Cannot use 'postDataRaw' when sending a GET request.")
     _validate_common_request_params(req)
 
     challenge_res = _resolve_challenge(req, "GET")
@@ -261,8 +263,10 @@ def _cmd_request_get(req: V1RequestBase) -> V1ResponseBase:
 
 def _cmd_request_post(req: V1RequestBase) -> V1ResponseBase:
     # do some validations
-    if req.postData is None:
-        raise Exception("Request parameter 'postData' is mandatory in 'request.post' command.")
+    if req.postData is None and req.postDataRaw is None:
+        raise Exception("Request parameter 'postData' or 'postDataRaw' is mandatory in 'request.post' command.")
+    if req.postData is not None and req.postDataRaw is not None:
+        raise Exception("Cannot use both 'postData' and 'postDataRaw' in the same request.")
     _validate_common_request_params(req)
 
     challenge_res = _resolve_challenge(req, "POST")
@@ -584,7 +588,8 @@ def _resolve_challenge(req: V1RequestBase, method: str) -> ChallengeResolutionT:
             session.lock.acquire()
             logging.debug(f"session lock acquired (session_id={session_id})")
         else:
-            driver = utils.get_webdriver(req.proxy, stealth_mode=req_stealth_mode)
+            logging_prefs = {"performance": "ALL"} if req.postDataRaw is not None else None
+            driver = utils.get_webdriver(req.proxy, stealth_mode=req_stealth_mode, logging_prefs=logging_prefs)
             if req.userAgent is not None:
                 utils.apply_user_agent_override(driver, req.userAgent, req.acceptLanguage or utils.get_config_accept_language())
             logging.debug("New instance of webdriver has been created to perform the request")
@@ -1034,9 +1039,103 @@ def _detect_captcha_type(driver: WebDriver) -> str | None:
     return None
 
 
+def _post_request_raw(req: V1RequestBase, driver: WebDriver) -> None:
+    if req.url is None:
+        raise Exception("Request parameter 'url' is mandatory in request commands.")
+    if req.postDataRaw is None:
+        raise Exception("Request parameter 'postDataRaw' is mandatory for raw POST requests.")
+
+    import base64
+    import json
+
+    target_url = req.url
+    post_data = req.postDataRaw
+    content_type = req.postDataContentType or "application/x-www-form-urlencoded"
+
+    # Enable Fetch interception for all requests so we catch the navigation
+    driver.execute_cdp_cmd("Fetch.enable", {"patterns": [{"urlPattern": "*", "requestStage": "Request"}]})
+
+    try:
+        # Navigate using CDP (non-blocking command)
+        nav_result = driver.execute_cdp_cmd("Page.navigate", {"url": target_url})
+        logging.debug(f"Page.navigate result: {nav_result}")
+
+        # Poll performance logs for the paused request
+        request_id = None
+        start_time = time.time()
+        timeout = 10
+
+        while time.time() - start_time < timeout:
+            try:
+                logs = driver.get_log("performance")
+            except Exception:
+                logs = []
+
+            for entry in logs:
+                try:
+                    msg = json.loads(entry["message"])["message"]
+                    if msg.get("method") == "Fetch.requestPaused":
+                        params = msg.get("params", {})
+                        paused_url = params.get("request", {}).get("url")
+                        paused_id = params["requestId"]
+                        if paused_url == target_url:
+                            request_id = paused_id
+                            break
+                        # Continue non-matching requests unchanged
+                        driver.execute_cdp_cmd("Fetch.continueRequest", {"requestId": paused_id})
+                except Exception:
+                    continue
+
+            if request_id is not None:
+                break
+            time.sleep(0.05)
+
+        if request_id is None:
+            raise Exception("Failed to intercept the POST request for raw body data.")
+
+        # Build headers including Content-Type and any custom headers
+        headers = [{"name": "Content-Type", "value": content_type}]
+        if req.headers:
+            for header in req.headers:
+                if isinstance(header, dict) and "name" in header and "value" in header:
+                    headers.append({"name": header["name"], "value": header["value"]})
+                elif isinstance(header, str) and ":" in header:
+                    name, value = header.split(":", 1)
+                    headers.append({"name": name.strip(), "value": value.strip()})
+
+        # Continue the intercepted request as POST with raw body
+        post_data_b64 = base64.b64encode(post_data.encode("utf-8")).decode("ascii")
+        driver.execute_cdp_cmd("Fetch.continueRequest", {
+            "requestId": request_id,
+            "method": "POST",
+            "postData": post_data_b64,
+            "headers": headers,
+        })
+
+        # Wait for the page to finish loading
+        load_timeout = 60
+        load_start = time.time()
+        while time.time() - load_start < load_timeout:
+            try:
+                ready_state = driver.execute_script("return document.readyState")
+            except Exception:
+                ready_state = None
+            if ready_state == "complete":
+                break
+            time.sleep(0.1)
+    finally:
+        try:
+            driver.execute_cdp_cmd("Fetch.disable", {})
+        except Exception:
+            pass
+
+
 def _post_request(req: V1RequestBase, driver: WebDriver) -> None:
     if req.url is None:
         raise Exception("Request parameter 'url' is mandatory in request commands.")
+    if req.postDataRaw is not None:
+        _post_request_raw(req, driver)
+        return
     post_form = f'<form id="hackForm" action="{req.url}" method="POST">'
     query_string = req.postData if req.postData and req.postData[0] != "?" else req.postData[1:] if req.postData else ""
     pairs = query_string.split("&")

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -698,7 +698,7 @@ class TestFlareSolverr(unittest.TestCase):
 
         body = V1ResponseBase(self._get_json(res))
         self.assertEqual(STATUS_ERROR, body.status)
-        self.assertIn("Request parameter 'postData' is mandatory in 'request.post' command", body.message)
+        self.assertIn("Request parameter 'postData' or 'postDataRaw' is mandatory in 'request.post' command", body.message)
 
     def test_v1_endpoint_request_post_deprecated_param(self):
         res = self._request("POST", "/v1", {"cmd": "request.post", "url": self.google_url, "postData": "param1=value1&param2=value2", "userAgent": "Test User-Agent"})
@@ -707,6 +707,56 @@ class TestFlareSolverr(unittest.TestCase):
         body = V1ResponseBase(self._get_json(res))
         self.assertEqual(STATUS_OK, body.status)
         self.assertEqual("Challenge not detected!", body.message)
+
+    def test_v1_endpoint_request_post_raw_json_no_cloudflare(self):
+        raw_body = '{"key": "value", "num": 42}'
+        res = self._request(
+            "POST",
+            "/v1",
+            {
+                "cmd": "request.post",
+                "url": self.post_url,
+                "postDataRaw": raw_body,
+                "postDataContentType": "application/json",
+            },
+        )
+        self.assertEqual(res.status_code, 200)
+
+        body = V1ResponseBase(self._get_json(res))
+        self.assertEqual(STATUS_OK, body.status)
+        self.assertEqual("Challenge not detected!", body.message)
+
+        solution = body.solution
+        self.assertIn(self.post_url, solution.url)
+        self.assertEqual(solution.status, 200)
+        self.assertIn(raw_body, solution.response)
+        self.assertIn('"Content-Type": "application/json"', solution.response)
+
+    def test_v1_endpoint_request_post_raw_fail_no_body(self):
+        res = self._request("POST", "/v1", {"cmd": "request.post", "url": self.google_url}, status=500)
+        self.assertEqual(res.status_code, 500)
+
+        body = V1ResponseBase(self._get_json(res))
+        self.assertEqual(STATUS_ERROR, body.status)
+        self.assertIn("Request parameter 'postData' or 'postDataRaw' is mandatory in 'request.post' command", body.message)
+
+    def test_v1_endpoint_request_post_raw_fail_both_bodies(self):
+        res = self._request(
+            "POST",
+            "/v1",
+            {
+                "cmd": "request.post",
+                "url": self.google_url,
+                "postData": "a=b",
+                "postDataRaw": "{}",
+            },
+            status=500,
+        )
+        self.assertEqual(res.status_code, 500)
+
+        body = V1ResponseBase(self._get_json(res))
+        self.assertEqual(STATUS_ERROR, body.status)
+        self.assertIn("Cannot use both 'postData' and 'postDataRaw' in the same request", body.message)
 
     def test_v1_endpoint_sessions_create_without_session(self):
         res = self._request("POST", "/v1", {"cmd": "sessions.create"})

--- a/tests/unit/test_post_raw.py
+++ b/tests/unit/test_post_raw.py
@@ -1,5 +1,7 @@
 """Tests for raw POST data support (postDataRaw / postDataContentType)."""
 
+from unittest.mock import patch
+
 from flaresolverr.dtos import V1RequestBase
 
 
@@ -58,11 +60,12 @@ class TestPostRawValidation:
         from flaresolverr import flaresolverr_service as service
 
         req = V1RequestBase({"cmd": "request.post", "url": "https://example.com"})
-        try:
-            service._cmd_request_post(req)
-            assert False, "Expected exception"
-        except Exception as e:
-            assert "postData" in str(e) and "postDataRaw" in str(e)
+        with patch.object(service, "_resolve_challenge"):
+            try:
+                service._cmd_request_post(req)
+                assert False, "Expected exception"
+            except Exception as e:
+                assert "postData" in str(e) and "postDataRaw" in str(e)
 
     def test_post_with_both_bodies_raises(self):
         from flaresolverr import flaresolverr_service as service
@@ -73,11 +76,12 @@ class TestPostRawValidation:
             "postData": "a=b",
             "postDataRaw": "{\"a\": \"b\"}",
         })
-        try:
-            service._cmd_request_post(req)
-            assert False, "Expected exception"
-        except Exception as e:
-            assert "Cannot use both" in str(e)
+        with patch.object(service, "_resolve_challenge"):
+            try:
+                service._cmd_request_post(req)
+                assert False, "Expected exception"
+            except Exception as e:
+                assert "Cannot use both" in str(e)
 
     def test_get_with_postDataRaw_raises(self):
         from flaresolverr import flaresolverr_service as service
@@ -87,11 +91,12 @@ class TestPostRawValidation:
             "url": "https://example.com",
             "postDataRaw": "test",
         })
-        try:
-            service._cmd_request_get(req)
-            assert False, "Expected exception"
-        except Exception as e:
-            assert "postDataRaw" in str(e)
+        with patch.object(service, "_resolve_challenge"):
+            try:
+                service._cmd_request_get(req)
+                assert False, "Expected exception"
+            except Exception as e:
+                assert "postDataRaw" in str(e)
 
     def test_post_with_postDataRaw_ok(self):
         """Validation should pass when only postDataRaw is provided."""
@@ -103,14 +108,9 @@ class TestPostRawValidation:
             "postDataRaw": "{\"key\": \"value\"}",
             "postDataContentType": "application/json",
         })
-        # _cmd_request_post calls _resolve_challenge which needs a real driver,
-        # so we only test validation indirectly by checking it doesn't raise here.
-        # The actual exception will be from _resolve_challenge (no driver), which is fine.
-        try:
+        with patch.object(service, "_resolve_challenge") as mock_resolve:
             service._cmd_request_post(req)
-        except Exception as e:
-            # Should NOT be a validation error
-            assert "postData" not in str(e) or "postDataRaw" not in str(e)
+            assert mock_resolve.called
 
 
 class TestPostRawCdpFlow:

--- a/tests/unit/test_post_raw.py
+++ b/tests/unit/test_post_raw.py
@@ -1,0 +1,238 @@
+"""Tests for raw POST data support (postDataRaw / postDataContentType)."""
+
+from flaresolverr.dtos import V1RequestBase
+
+
+class MockDriverRawPost:
+    """Mock WebDriver that simulates CDP Fetch interception for raw POST."""
+
+    def __init__(self, simulate_fail=False, missing_logs=False):
+        self.current_url = "https://example.com"
+        self.page_source = "<html><body>OK</body></html>"
+        self._cdp_calls = []
+        self._simulate_fail = simulate_fail
+        self._missing_logs = missing_logs
+        self._fetch_enabled = False
+        self._navigated = False
+        self._logs_consumed = False
+
+    def execute_cdp_cmd(self, cmd, params):
+        self._cdp_calls.append((cmd, params))
+        if cmd == "Fetch.enable":
+            self._fetch_enabled = True
+            return {}
+        if cmd == "Fetch.disable":
+            self._fetch_enabled = False
+            return {}
+        if cmd == "Page.navigate":
+            self._navigated = True
+            return {"frameId": "mock-frame", "loaderId": "mock-loader"}
+        if cmd == "Fetch.continueRequest":
+            return {}
+        return {}
+
+    def get_log(self, log_type):
+        if log_type != "performance":
+            return []
+        if self._missing_logs or self._logs_consumed:
+            return []
+        self._logs_consumed = True
+        if self._simulate_fail:
+            return []
+        return [
+            {
+                "message": '{"message": {"method": "Fetch.requestPaused", "params": {"requestId": "req-1", "request": {"url": "https://example.com/api"}, "resourceType": "Document"}}}'
+            }
+        ]
+
+    def execute_script(self, script):
+        if "document.readyState" in script:
+            return "complete"
+        return None
+
+
+class TestPostRawValidation:
+    """Tests for request validation with postDataRaw."""
+
+    def test_post_missing_body_raises(self):
+        from flaresolverr import flaresolverr_service as service
+
+        req = V1RequestBase({"cmd": "request.post", "url": "https://example.com"})
+        try:
+            service._cmd_request_post(req)
+            assert False, "Expected exception"
+        except Exception as e:
+            assert "postData" in str(e) and "postDataRaw" in str(e)
+
+    def test_post_with_both_bodies_raises(self):
+        from flaresolverr import flaresolverr_service as service
+
+        req = V1RequestBase({
+            "cmd": "request.post",
+            "url": "https://example.com",
+            "postData": "a=b",
+            "postDataRaw": "{\"a\": \"b\"}",
+        })
+        try:
+            service._cmd_request_post(req)
+            assert False, "Expected exception"
+        except Exception as e:
+            assert "Cannot use both" in str(e)
+
+    def test_get_with_postDataRaw_raises(self):
+        from flaresolverr import flaresolverr_service as service
+
+        req = V1RequestBase({
+            "cmd": "request.get",
+            "url": "https://example.com",
+            "postDataRaw": "test",
+        })
+        try:
+            service._cmd_request_get(req)
+            assert False, "Expected exception"
+        except Exception as e:
+            assert "postDataRaw" in str(e)
+
+    def test_post_with_postDataRaw_ok(self):
+        """Validation should pass when only postDataRaw is provided."""
+        from flaresolverr import flaresolverr_service as service
+
+        req = V1RequestBase({
+            "cmd": "request.post",
+            "url": "https://example.com",
+            "postDataRaw": "{\"key\": \"value\"}",
+            "postDataContentType": "application/json",
+        })
+        # _cmd_request_post calls _resolve_challenge which needs a real driver,
+        # so we only test validation indirectly by checking it doesn't raise here.
+        # The actual exception will be from _resolve_challenge (no driver), which is fine.
+        try:
+            service._cmd_request_post(req)
+        except Exception as e:
+            # Should NOT be a validation error
+            assert "postData" not in str(e) or "postDataRaw" not in str(e)
+
+
+class TestPostRawCdpFlow:
+    """Tests for the CDP-based raw POST flow."""
+
+    def test_fetch_enable_and_navigate(self):
+        from flaresolverr import flaresolverr_service as service
+
+        req = V1RequestBase({
+            "cmd": "request.post",
+            "url": "https://example.com/api",
+            "postDataRaw": '{"key": "value"}',
+            "postDataContentType": "application/json",
+        })
+        driver = MockDriverRawPost()
+        service._post_request_raw(req, driver)
+
+        assert driver._navigated
+        # Check Fetch.enable was called with wildcard pattern
+        enable_cmd = [c for c in driver._cdp_calls if c[0] == "Fetch.enable"]
+        assert len(enable_cmd) == 1
+        assert enable_cmd[0][1]["patterns"][0]["urlPattern"] == "*"
+        # Fetch.disable should also be called for cleanup
+        disable_cmd = [c for c in driver._cdp_calls if c[0] == "Fetch.disable"]
+        assert len(disable_cmd) == 1
+
+    def test_continue_request_with_headers(self):
+        from flaresolverr import flaresolverr_service as service
+
+        req = V1RequestBase({
+            "cmd": "request.post",
+            "url": "https://example.com/api",
+            "postDataRaw": '{"key": "value"}',
+            "postDataContentType": "application/json",
+            "headers": [{"name": "X-Custom", "value": "123"}],
+        })
+        driver = MockDriverRawPost()
+        service._post_request_raw(req, driver)
+
+        continue_calls = [c for c in driver._cdp_calls if c[0] == "Fetch.continueRequest"]
+        assert len(continue_calls) == 1
+        params = continue_calls[0][1]
+        assert params["method"] == "POST"
+        assert params["requestId"] == "req-1"
+        # Check Content-Type header is present
+        header_names = {h["name"] for h in params["headers"]}
+        assert "Content-Type" in header_names
+        assert "X-Custom" in header_names
+
+    def test_disable_called_after_completion(self):
+        from flaresolverr import flaresolverr_service as service
+
+        req = V1RequestBase({
+            "cmd": "request.post",
+            "url": "https://example.com/api",
+            "postDataRaw": "test",
+        })
+        driver = MockDriverRawPost()
+        service._post_request_raw(req, driver)
+
+        disable_calls = [c for c in driver._cdp_calls if c[0] == "Fetch.disable"]
+        assert len(disable_calls) == 1
+
+    def test_fails_when_intercept_not_found(self):
+        from flaresolverr import flaresolverr_service as service
+
+        req = V1RequestBase({
+            "cmd": "request.post",
+            "url": "https://example.com/api",
+            "postDataRaw": "test",
+        })
+        driver = MockDriverRawPost(simulate_fail=True)
+        try:
+            service._post_request_raw(req, driver)
+            assert False, "Expected exception"
+        except Exception as e:
+            assert "Failed to intercept" in str(e)
+
+    def test_post_request_delegates_to_raw(self):
+        from flaresolverr import flaresolverr_service as service
+
+        req = V1RequestBase({
+            "cmd": "request.post",
+            "url": "https://example.com/api",
+            "postDataRaw": "test",
+        })
+        driver = MockDriverRawPost()
+        service._post_request(req, driver)
+
+        # Should have gone through the raw path
+        assert driver._navigated
+
+    def test_post_request_uses_form_for_postData(self):
+        from flaresolverr import flaresolverr_service as service
+
+        req = V1RequestBase({
+            "cmd": "request.post",
+            "url": "https://example.com/api",
+            "postData": "field=value",
+        })
+
+        class MinimalDriver:
+            def __init__(self):
+                self._url = None
+
+            def get(self, url):
+                self._url = url
+
+        driver = MinimalDriver()
+        service._post_request(req, driver)
+
+        assert driver._url is not None
+        assert "hackForm" in driver._url
+
+
+class TestDtoFields:
+    """Tests for the new DTO fields."""
+
+    def test_postDataRaw_field_exists(self):
+        req = V1RequestBase({"postDataRaw": "raw body"})
+        assert req.postDataRaw == "raw body"
+
+    def test_postDataContentType_field_exists(self):
+        req = V1RequestBase({"postDataContentType": "application/json"})
+        assert req.postDataContentType == "application/json"


### PR DESCRIPTION
## Summary

Closes #35 — adds the ability to send raw and JSON POST data through FlareSolverr, which was previously limited to `application/x-www-form-urlencoded` form-encoded data.

## New request parameters

- `postDataRaw` — raw body content sent without form encoding
- `postDataContentType` — custom `Content-Type` header (default: `application/x-www-form-urlencoded`)

## Usage example

```json
{
  "cmd": "request.post",
  "url": "https://example.com/api",
  "postDataRaw": "{\"key\": \"value\"}",
  "postDataContentType": "application/json"
}
```

## Implementation

- **DTO**: added `postDataRaw` and `postDataContentType` fields to `V1RequestBase`
- **Validation**: `request.post` accepts either `postData` or `postDataRaw`; `request.get` rejects `postDataRaw`
- **Raw POST flow**: implemented via Chrome DevTools Protocol `Fetch` interception (`Fetch.enable` → `Page.navigate` → intercept `Fetch.requestPaused` → `Fetch.continueRequest` with base64-encoded body and headers)
- **Client library**: updated `FlareSolverrClient.post()` with `post_data_raw` and `post_data_content_type` kwargs
- **Tests**: added `tests/unit/test_post_raw.py` covering validation, CDP flow, and delegation logic

## References

- https://github.com/FlareSolverr/FlareSolverr/issues/1519
- https://github.com/FlareSolverr/FlareSolverr/issues/424
- https://github.com/FlareSolverr/FlareSolverr/issues/254