### PR TITLE
feat: dynamic proxy switching for Chrome sessions

### DIFF
--- a/API.md
+++ b/API.md
@@ -59,7 +59,7 @@ This also speeds up the requests since it won't have to launch a new browser ins
 | Parameter | Notes |
 | --------- | ----- |
 | session | Optional. The session ID that you want to be assigned to the instance. If isn't set a random UUID will be assigned. |
-| proxy | Optional, default disabled. Eg: `"proxy": {"url": "http://127.0.0.1:8888"}`. You must include the proxy schema in the URL: `http://`, `socks4://` or `socks5://`. Authorization (username/password) is supported. |
+| proxy | Optional, default disabled. Eg: `"proxy": {"url": "http://127.0.0.1:8888"}`. You must include the proxy schema in the URL: `http://`, `socks4://` or `socks5://`. Authorization (username/password) is supported. Proxy can also be changed dynamically when reusing a session via `request.get` / `request.post`. |
 | stealth | Optional, default uses `STEALTH_MODE`. Enables/disables stealth patches for this session. |
 | stealthMode | Optional enum override: `"off"`, `"standard"`, `"csp-safe"`. Preferred over `stealth` for explicit behavior. |
 | userAgent | Optional. Custom browser user agent for the session. |
@@ -208,7 +208,7 @@ Example:
 | headers | Optional. Custom HTTP headers to send with the request. |
 | returnOnlyCookies | Optional, default false. Only returns the cookies. |
 | returnScreenshot | Optional, default false. Captures a screenshot as Base64 PNG. |
-| proxy | Optional, default disabled. Eg: `"proxy": {"url": "http://127.0.0.1:8888"}`. |
+| proxy | Optional, default disabled. Eg: `"proxy": {"url": "http://127.0.0.1:8888"}`. When a `session` is provided and `proxy` is passed, the session's proxy is updated dynamically without restarting Chrome. Omitting `proxy` on a reused session keeps the previously set proxy sticky. Passing an explicit empty proxy (`{}` or `{"url": ""}`) clears the proxy on that session. |
 | waitInSeconds | Optional. Wait after solving the challenge before returning results. |
 | disableMedia | Optional, default false. Block images/CSS/fonts to speed up navigation. |
 | tabs_till_verify | Optional. Number of Tab presses needed for turnstile captcha. |
@@ -237,6 +237,29 @@ This works like `request.get`, with the addition of the `postData` / `postDataRa
 
 > **Note**
 > Only one of `postData` or `postDataRaw` can be used in a single request, not both.
+
+> **Session Proxy Reuse**
+> You can reuse a session and switch proxies on the fly. This is useful for proxy pools where you want to keep a warm pool of browser instances and rotate proxies per request:
+>
+> ```json
+> {
+>   "cmd": "request.get",
+>   "session": "my-session",
+>   "url": "https://example.com",
+>   "proxy": {"url": "http://proxy-pool:8080"}
+> }
+> ```
+>
+> The next request to the same session can use a different proxy (or omit `proxy` to keep the current one):
+>
+> ```json
+> {
+>   "cmd": "request.get",
+>   "session": "my-session",
+>   "url": "https://example.com",
+>   "proxy": {"url": "http://another-proxy:8080"}
+> }
+> ```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ bypass Cloudflare using other HTTP clients.
 **NOTE**: Web browsers consume a lot of memory. If you are running FlareSolverr on a machine with few RAM, do not make
 many requests at once and/or limit the parallel sessions with the `MAX_SESSIONS` environment variable. With each request a new browser is launched.
 
-It is also possible to use a permanent session. However, if you use sessions, you should make sure to close them as
-soon as you are done using them.
+It is also possible to use a permanent session. Sessions support dynamic proxy switching, so you can keep a pool of pre-warmed browser instances and rotate proxies per request without restarting Chrome. If you use sessions, you should make sure to close them as soon as you are done using them.
 
 ## Installation
 

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -6,6 +6,13 @@ services:
     ports:
       - "127.0.0.1:8888:8888"
 
+  proxy-http-2:
+    build:
+      context: .github/docker/tinyproxy
+      dockerfile: Dockerfile
+    ports:
+      - "127.0.0.1:8889:8888"
+
   proxy-socks:
     image: serjs/go-socks5-proxy:latest
     environment:

--- a/src/flaresolverr/flaresolverr_service.py
+++ b/src/flaresolverr/flaresolverr_service.py
@@ -579,6 +579,7 @@ def _resolve_challenge(req: V1RequestBase, method: str) -> ChallengeResolutionT:
             session, fresh = SESSIONS_STORAGE.get(
                 session_id,
                 ttl,
+                proxy=req.proxy,
                 stealth_mode=req_stealth_mode,
                 user_agent=req.userAgent,
                 accept_language=req.acceptLanguage,

--- a/src/flaresolverr/proxy_extension/background.js
+++ b/src/flaresolverr/proxy_extension/background.js
@@ -1,0 +1,119 @@
+// Background service worker to manage Chrome proxy settings dynamically.
+// Supports both authenticated and unauthenticated proxies via chrome.proxy API.
+
+var FLARESOLVERR_PROXY_KEY = "flaresolverrProxy";
+var currentAuth = null;
+
+/**
+ * Apply proxy settings to Chrome.
+ * @param {Object} proxyConfig - The proxy configuration object.
+ */
+function applyProxyConfig(proxyConfig, callback) {
+    chrome.proxy.settings.set(
+        { value: proxyConfig, scope: "regular" },
+        function() {
+            if (chrome.runtime.lastError) {
+                callback({ success: false, error: chrome.runtime.lastError.message });
+            } else {
+                callback({ success: true });
+            }
+        }
+    );
+}
+
+/**
+ * Restore proxy config from storage on startup.
+ */
+function restoreProxyFromStorage() {
+    chrome.storage.local.get([FLARESOLVERR_PROXY_KEY, "flaresolverrProxyAuth"], function(result) {
+        var config = result[FLARESOLVERR_PROXY_KEY];
+        currentAuth = result.flaresolverrProxyAuth || null;
+        if (config) {
+            applyProxyConfig(config, function() {});
+        } else {
+            // Default to direct (no proxy)
+            applyProxyConfig({ mode: "direct" }, function() {});
+        }
+    });
+}
+
+// Restore on startup
+restoreProxyFromStorage();
+
+// Handle messages from content script or extension pages
+chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+    if (!request || !request.mode) {
+        sendResponse({ success: false, error: "Missing mode" });
+        return false;
+    }
+
+    try {
+        if (request.mode === "direct") {
+            applyProxyConfig({ mode: "direct" }, function(result) {
+                if (result.success) {
+                    currentAuth = null;
+                    chrome.storage.local.remove([FLARESOLVERR_PROXY_KEY]);
+                    chrome.storage.local.remove(["flaresolverrProxyAuth"]);
+                }
+                sendResponse(result);
+            });
+        } else if (request.mode === "fixed_servers") {
+            var proxyConfig = {
+                mode: "fixed_servers",
+                rules: request.rules
+            };
+            var newAuth = (request.auth && request.auth.username) ? request.auth : null;
+            applyProxyConfig(proxyConfig, function(result) {
+                if (result.success) {
+                    currentAuth = newAuth;
+                    chrome.storage.local.set({ [FLARESOLVERR_PROXY_KEY]: proxyConfig });
+                    if (currentAuth) {
+                        chrome.storage.local.set({ flaresolverrProxyAuth: currentAuth });
+                    } else {
+                        chrome.storage.local.remove(["flaresolverrProxyAuth"]);
+                    }
+                }
+                sendResponse(result);
+            });
+        } else {
+            sendResponse({ success: false, error: "Unknown mode: " + request.mode });
+        }
+    } catch (err) {
+        sendResponse({ success: false, error: err.message });
+    }
+    return true;
+});
+
+// Handle proxy authentication
+chrome.webRequest.onAuthRequired.addListener(
+    function(details, callbackFn) {
+        // currentAuth is updated synchronously in onMessage so there is never
+        // a race between ACK and the first onAuthRequired event.
+        if (currentAuth && currentAuth.username) {
+            callbackFn({
+                authCredentials: {
+                    username: currentAuth.username,
+                    password: currentAuth.password || ""
+                }
+            });
+            return;
+        }
+        // Fallback to storage (e.g. service worker restart).
+        chrome.storage.local.get(["flaresolverrProxyAuth"], function(result) {
+            var auth = result.flaresolverrProxyAuth;
+            if (auth && auth.username) {
+                currentAuth = auth;
+                callbackFn({
+                    authCredentials: {
+                        username: auth.username,
+                        password: auth.password || ""
+                    }
+                });
+            } else {
+                callbackFn();
+            }
+        });
+    },
+    { urls: ["<all_urls>"] },
+    ["asyncBlocking"]
+);

--- a/src/flaresolverr/proxy_extension/manifest.json
+++ b/src/flaresolverr/proxy_extension/manifest.json
@@ -1,0 +1,17 @@
+{
+    "version": "1.0.0",
+    "manifest_version": 3,
+    "name": "FlareSolverr Proxy Manager",
+    "permissions": [
+        "proxy",
+        "storage",
+        "webRequest",
+        "webRequestAuthProvider"
+    ],
+    "host_permissions": [
+        "<all_urls>"
+    ],
+    "background": {
+        "service_worker": "background.js"
+    }
+}

--- a/src/flaresolverr/proxy_extension/proxy.html
+++ b/src/flaresolverr/proxy_extension/proxy.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>FlareSolverr Proxy Manager</title>
+</head>
+<body>
+<script>
+// Stable extension page used as a command channel for proxy updates.
+// The Python side navigates here and executes scripts that call
+// chrome.runtime.sendMessage directly (extension pages have that API).
+window.__FS_PROXY_RESULT = null;
+</script>
+</body>
+</html>

--- a/src/flaresolverr/sessions.py
+++ b/src/flaresolverr/sessions.py
@@ -138,6 +138,62 @@ class SessionsStorage:
         self._cleanup_thread: threading.Thread | None = None
         self._stop_cleanup = threading.Event()
 
+    def _reuse_existing_session(
+        self,
+        session: Session,
+        proxy: Optional[dict[str, Any]] = None,
+        stealth_mode: Optional[str | bool] = None,
+        user_agent: Optional[str] = None,
+        accept_language: Optional[str] = None,
+        enabled_services: Optional[list[str]] = None,
+    ) -> Session:
+        """Validate settings and apply dynamic updates on an existing session."""
+        if stealth_mode is not None:
+            normalized_mode = utils.normalize_stealth_mode(stealth_mode)
+            if session.stealth_mode != normalized_mode:
+                raise ValueError(
+                    f"Session '{session.session_id}' already exists with stealthMode={session.stealth_mode!r}. "
+                    f"Requested stealthMode={normalized_mode!r}. Destroy/recreate the session to change this setting."
+                )
+        if user_agent is not None:
+            if session.user_agent_override is None and session.request_count == 0:
+                utils.apply_user_agent_override(session.driver, user_agent, accept_language or utils.get_config_accept_language())
+                session.user_agent_override = user_agent
+            elif session.user_agent_override != user_agent:
+                raise ValueError(
+                    f"Session '{session.session_id}' already initialized with userAgent={session.user_agent_override!r}. "
+                    f"Requested userAgent={user_agent!r}. Destroy/recreate the session to change this setting."
+                )
+        if accept_language is not None:
+            if session.accept_language_override is None and session.request_count == 0:
+                if session.user_agent_override is not None:
+                    utils.apply_user_agent_override(session.driver, session.user_agent_override, accept_language)
+                session.accept_language_override = accept_language
+            elif session.accept_language_override != accept_language:
+                raise ValueError(
+                    f"Session '{session.session_id}' already initialized with acceptLanguage={session.accept_language_override!r}. "
+                    f"Requested acceptLanguage={accept_language!r}. Destroy/recreate the session to change this setting."
+                )
+        if enabled_services is not None:
+            if session.enabled_services != enabled_services:
+                raise ValueError(
+                    f"Session '{session.session_id}' already initialized with enabledServices={session.enabled_services!r}. "
+                    f"Requested enabledServices={enabled_services!r}. Destroy/recreate the session to change this setting."
+                )
+        # Dynamic proxy update on reused sessions
+        if proxy is not None:
+            if utils._is_proxy_empty(proxy):
+                if session.proxy is not None:
+                    utils.apply_proxy_to_session(session.driver, proxy)
+                    session.proxy = None
+            elif utils._is_proxy_valid(proxy):
+                if session.proxy != proxy:
+                    utils.apply_proxy_to_session(session.driver, proxy)
+                    session.proxy = proxy
+            else:
+                raise RuntimeError(f"Invalid proxy config (schema required, e.g. http://): {proxy!r}")
+        return session
+
     def create(
         self,
         session_id: Optional[str] = None,
@@ -168,51 +224,15 @@ class SessionsStorage:
 
             if self.exists(session_id):
                 existing_session = self.sessions[session_id]
-                if stealth_mode is not None:
-                    normalized_mode = utils.normalize_stealth_mode(stealth_mode)
-                    if existing_session.stealth_mode != normalized_mode:
-                        raise ValueError(
-                            f"Session '{session_id}' already exists with stealthMode={existing_session.stealth_mode!r}. "
-                            f"Requested stealthMode={normalized_mode!r}. Destroy/recreate the session to change this setting."
-                        )
-                if user_agent is not None:
-                    if existing_session.user_agent_override is None and existing_session.request_count == 0:
-                        utils.apply_user_agent_override(existing_session.driver, user_agent, accept_language or utils.get_config_accept_language())
-                        existing_session.user_agent_override = user_agent
-                    elif existing_session.user_agent_override != user_agent:
-                        raise ValueError(
-                            f"Session '{session_id}' already initialized with userAgent={existing_session.user_agent_override!r}. "
-                            f"Requested userAgent={user_agent!r}. Destroy/recreate the session to change this setting."
-                        )
-                if accept_language is not None:
-                    if existing_session.accept_language_override is None and existing_session.request_count == 0:
-                        if existing_session.user_agent_override is not None:
-                            utils.apply_user_agent_override(existing_session.driver, existing_session.user_agent_override, accept_language)
-                        existing_session.accept_language_override = accept_language
-                    elif existing_session.accept_language_override != accept_language:
-                        raise ValueError(
-                            f"Session '{session_id}' already initialized with acceptLanguage={existing_session.accept_language_override!r}. "
-                            f"Requested acceptLanguage={accept_language!r}. Destroy/recreate the session to change this setting."
-                        )
-                if enabled_services is not None:
-                    if existing_session.enabled_services != enabled_services:
-                        raise ValueError(
-                            f"Session '{session_id}' already initialized with enabledServices={existing_session.enabled_services!r}. "
-                            f"Requested enabledServices={enabled_services!r}. Destroy/recreate the session to change this setting."
-                        )
-                # Dynamic proxy update on reused sessions
-                if proxy is not None:
-                    if utils._is_proxy_empty(proxy):
-                        if existing_session.proxy is not None:
-                            utils.apply_proxy_to_session(existing_session.driver, proxy)
-                            existing_session.proxy = None
-                    elif utils._is_proxy_valid(proxy):
-                        if existing_session.proxy != proxy:
-                            utils.apply_proxy_to_session(existing_session.driver, proxy)
-                            existing_session.proxy = proxy
-                    else:
-                        raise RuntimeError(f"Invalid proxy config (schema required, e.g. http://): {proxy!r}")
-                return self.sessions[session_id], False
+                self._reuse_existing_session(
+                    existing_session,
+                    proxy=proxy,
+                    stealth_mode=stealth_mode,
+                    user_agent=user_agent,
+                    accept_language=accept_language,
+                    enabled_services=enabled_services,
+                )
+                return existing_session, False
 
             max_count = utils.get_config_session_max_count()
             if max_count is not None and len(self.sessions) >= max_count:

--- a/src/flaresolverr/sessions.py
+++ b/src/flaresolverr/sessions.py
@@ -85,6 +85,7 @@ class Session:
     last_used_at: datetime
     max_runtime: timedelta | None
     idle_timeout: timedelta
+    proxy: dict[str, Any] | None
 
     def __init__(
         self,
@@ -97,6 +98,7 @@ class Session:
         enabled_services: list[str] | None = None,
         max_runtime: timedelta | None = None,
         idle_timeout: timedelta | None = None,
+        proxy: dict[str, Any] | None = None,
     ):
         self.session_id = session_id
         self.driver = driver
@@ -110,6 +112,7 @@ class Session:
         self.last_used_at = created_at
         self.max_runtime = max_runtime
         self.idle_timeout = idle_timeout if idle_timeout is not None else utils.get_config_session_idle_timeout()
+        self.proxy = proxy
 
     def lifetime(self) -> timedelta:
         return datetime.now() - self.created_at
@@ -197,6 +200,18 @@ class SessionsStorage:
                             f"Session '{session_id}' already initialized with enabledServices={existing_session.enabled_services!r}. "
                             f"Requested enabledServices={enabled_services!r}. Destroy/recreate the session to change this setting."
                         )
+                # Dynamic proxy update on reused sessions
+                if proxy is not None:
+                    if utils._is_proxy_empty(proxy):
+                        if existing_session.proxy is not None:
+                            utils.apply_proxy_to_session(existing_session.driver, proxy)
+                            existing_session.proxy = None
+                    elif utils._is_proxy_valid(proxy):
+                        if existing_session.proxy != proxy:
+                            utils.apply_proxy_to_session(existing_session.driver, proxy)
+                            existing_session.proxy = proxy
+                    else:
+                        raise RuntimeError(f"Invalid proxy config (schema required, e.g. http://): {proxy!r}")
                 return self.sessions[session_id], False
 
             max_count = utils.get_config_session_max_count()
@@ -226,6 +241,7 @@ class SessionsStorage:
                 enabled_services=effective_enabled_services,
                 max_runtime=effective_max_runtime,
                 idle_timeout=effective_idle_timeout,
+                proxy=proxy,
             )
 
             self.sessions[session_id] = session
@@ -276,9 +292,11 @@ class SessionsStorage:
         enabled_services: Optional[list[str]] = None,
         max_runtime: Optional[timedelta] = None,
         idle_timeout: Optional[timedelta] = None,
+        proxy: Optional[dict[str, Any]] = None,
     ) -> Tuple[Session, bool]:
         session, fresh = self.create(
             session_id,
+            proxy=proxy,
             stealth_mode=stealth_mode,
             user_agent=user_agent,
             accept_language=accept_language,
@@ -292,6 +310,7 @@ class SessionsStorage:
             session, fresh = self.create(
                 session_id,
                 force_new=True,
+                proxy=proxy,
                 stealth_mode=stealth_mode,
                 user_agent=user_agent,
                 accept_language=accept_language,

--- a/src/flaresolverr/utils.py
+++ b/src/flaresolverr/utils.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import logging
 import os
@@ -333,75 +334,41 @@ def get_current_platform() -> str:
     return PLATFORM_VERSION
 
 
-def create_proxy_extension(proxy: dict[str, Any]) -> str:
-    parsed_url = urllib.parse.urlparse(proxy["url"])
-    scheme = parsed_url.scheme
-    host = parsed_url.hostname
-    port = parsed_url.port
-    username = proxy["username"]
-    password = proxy["password"]
-    manifest_json = """
-    {
-        "version": "1.0.0",
-        "manifest_version": 3,
-        "name": "Chrome Proxy",
-        "permissions": [
-            "proxy",
-            "tabs",
-            "storage",
-            "webRequest",
-            "webRequestAuthProvider"
-        ],
-        "host_permissions": [
-          "<all_urls>"
-        ],
-        "background": {
-          "service_worker": "background.js"
-        },
-        "minimum_chrome_version": "76.0.0"
-    }
+def _get_proxy_extension_dir() -> str:
+    """Return the path to the static proxy-manager Chrome extension."""
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "proxy_extension")
+
+
+def _compute_extension_id(extension_path: str) -> str:
+    """Compute the Chrome extension ID for an unpacked extension.
+
+    Chrome derives the extension ID from the SHA-256 of the absolute path.
+    The first 16 bytes of the digest are encoded with alphabet a-p.
     """
+    normalized = extension_path.replace("\\", "/").encode("utf-8")
+    digest = hashlib.sha256(normalized).digest()[:16]
+    alphabet = "abcdefghijklmnop"
+    return "".join(alphabet[b >> 4] + alphabet[b & 0x0F] for b in digest)
 
-    background_js = """
-    var config = {
-        mode: "fixed_servers",
-        rules: {
-            singleProxy: {
-                scheme: "%s",
-                host: "%s",
-                port: %d
-            },
-            bypassList: ["localhost"]
-        }
-    };
 
-    chrome.proxy.settings.set({value: config, scope: "regular"}, function() {});
+def _build_stealth_extension_dir() -> tuple[str, str]:
+    """Create a temporary copy of the proxy extension.
 
-    function callbackFn(details) {
-        return {
-            authCredentials: {
-                username: "%s",
-                password: "%s"
-            }
-        };
-    }
+    Returns (temp_extension_dir, extension_id) so the caller can
+    navigate to the extension's proxy.html page directly.
+    """
+    static_dir = _get_proxy_extension_dir()
+    temp_dir = tempfile.mkdtemp(prefix="fspe-")
 
-    chrome.webRequest.onAuthRequired.addListener(
-        callbackFn,
-        { urls: ["<all_urls>"] },
-        ['blocking']
-    );
-    """ % (scheme, host, port, username, password)
+    for fname in os.listdir(static_dir):
+        src = os.path.join(static_dir, fname)
+        if not os.path.isfile(src):
+            continue
+        dst = os.path.join(temp_dir, fname)
+        shutil.copy2(src, dst)
 
-    proxy_extension_dir = tempfile.mkdtemp()
-
-    with open(os.path.join(proxy_extension_dir, "manifest.json"), "w") as f:
-        f.write(manifest_json)
-
-    with open(os.path.join(proxy_extension_dir, "background.js"), "w") as f:
-        f.write(background_js)
-
-    return proxy_extension_dir
+    ext_id = _compute_extension_id(temp_dir)
+    return temp_dir, ext_id
 
 
 def _build_chrome_options(effective_stealth_mode: str) -> ChromeOptions:
@@ -486,27 +453,100 @@ def _check_proxy_reachable(proxy_url: str) -> None:
         raise RuntimeError(f"Proxy {host}:{port} is not reachable: {e}") from e
 
 
-def _handle_proxy_setup(options: ChromeOptions, proxy: dict[str, Any] | None) -> str | None:
-    """Configure proxy settings and return extension directory if created."""
+def _is_proxy_empty(proxy: dict[str, Any] | None) -> bool:
+    """Return True if the proxy dict represents an explicit clear/empty proxy."""
     if proxy is None:
-        return None
+        return False
+    url = proxy.get("url", "")
+    return url == ""
 
-    if all(key in proxy for key in ["url", "username", "password"]):
-        _check_proxy_reachable(proxy["url"])
-        proxy_extension_dir = create_proxy_extension(proxy)
-        options.add_argument("--disable-features=DisableLoadExtensionCommandLineSwitch")
-        options.add_argument("--load-extension=%s" % os.path.abspath(proxy_extension_dir))
-        return proxy_extension_dir
 
-    if "url" in proxy:
+def _is_proxy_valid(proxy: dict[str, Any] | None) -> bool:
+    """Return True if the proxy dict contains a valid proxy URL."""
+    if proxy is None:
+        return False
+    url = proxy.get("url", "")
+    return bool(url) and "://" in url
+
+
+def apply_proxy_to_session(driver: WebDriver, proxy: dict[str, Any] | None) -> None:
+    """Dynamically update proxy on a running Chrome session via the proxy-manager extension.
+
+    Navigates to the extension's proxy.html page and calls chrome.runtime.sendMessage
+    directly to the background service worker, which updates chrome.proxy.settings.set.
+    Waits for an acknowledgement from the extension and raises on failure/timeout.
+    """
+    if proxy is None:
+        return
+
+    # Determine whether this is a clear or set operation
+    if _is_proxy_empty(proxy):
+        payload = {"mode": "direct"}
+        logging.debug("Clearing proxy on session via extension")
+    elif not _is_proxy_valid(proxy):
+        raise RuntimeError(f"Invalid proxy config (schema required, e.g. http://): {proxy!r}")
+    else:
         proxy_url = proxy["url"]
         _check_proxy_reachable(proxy_url)
-        logging.debug("Using webdriver proxy: %s", proxy_url)
-        options.add_argument("--proxy-server=%s" % proxy_url)
-        # Explicitly disable proxy bypass so Chrome uses the proxy for all hosts
-        options.add_argument("--proxy-bypass-list=")
+        parsed = urllib.parse.urlparse(proxy_url)
+        scheme = parsed.scheme
+        host = parsed.hostname
+        port = parsed.port
+        if not host or not port:
+            raise RuntimeError(f"Invalid proxy URL (cannot parse host/port): {proxy_url!r}")
+        payload = {
+            "mode": "fixed_servers",
+            "rules": {
+                "singleProxy": {
+                    "scheme": scheme,
+                    "host": host,
+                    "port": port,
+                },
+                "bypassList": ["localhost"],
+            },
+        }
+        username = proxy.get("username")
+        password = proxy.get("password")
+        if username:
+            payload["auth"] = {"username": username, "password": password or ""}
+        logging.debug("Applying proxy to session via extension: %s:%d", host, port)
 
-    return None
+    # Navigate to the extension's proxy.html page so we have a stable
+    # extension context where chrome.runtime.sendMessage is available.
+    ext_id = getattr(driver, "_proxy_ext_id", None)
+    if not ext_id:
+        raise RuntimeError("Extension ID not available on driver; cannot apply proxy")
+    driver.get("chrome-extension://%s/proxy.html" % ext_id)
+
+    # Smoke check: verify we are on a live extension page by reading chrome.runtime.id
+    actual_ext_id = driver.execute_script("return chrome.runtime.id")
+    if actual_ext_id != ext_id:
+        raise RuntimeError(
+            f"Extension ID mismatch: expected {ext_id!r}, got {actual_ext_id!r}. The computed extension ID does not match Chrome's actual extension ID."
+        )
+
+    # Directly call chrome.runtime.sendMessage from the extension page
+    script = """
+        (function() {
+            window.__FS_PROXY_RESULT = null;
+            chrome.runtime.sendMessage(%s, function(response) {
+                window.__FS_PROXY_RESULT = response || {success: false, error: "no response"};
+            });
+        })();
+    """ % json.dumps(payload)
+    driver.execute_script(script)
+
+    # Poll for acknowledgement (max 5 seconds)
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        result = driver.execute_script("return window.__FS_PROXY_RESULT")
+        if result is not None:
+            if result.get("success"):
+                return
+            raise RuntimeError(f"Proxy extension failed to apply proxy: {result.get('error', 'unknown')}")
+        time.sleep(0.05)
+
+    raise RuntimeError("Proxy extension did not acknowledge within timeout")
 
 
 def _resolve_driver_paths() -> tuple[str | None, str | None]:
@@ -672,7 +712,9 @@ def get_webdriver(proxy: dict[str, Any] | None = None, stealth_mode: str | bool 
     effective_stealth_mode = get_config_stealth_mode() if stealth_mode is None else normalize_stealth_mode(stealth_mode)
 
     options = _build_chrome_options(effective_stealth_mode)
-    proxy_extension_dir = _handle_proxy_setup(options, proxy)
+    proxy_ext_dir, proxy_ext_id = _build_stealth_extension_dir()
+    options.add_argument("--disable-features=DisableLoadExtensionCommandLineSwitch")
+    options.add_argument("--load-extension=%s" % os.path.abspath(proxy_ext_dir))
     windows_headless = _configure_headless()
     driver_exe_path, version_main = _resolve_driver_paths()
     browser_executable_path = get_chrome_exe_path()
@@ -724,6 +766,8 @@ def get_webdriver(proxy: dict[str, Any] | None = None, stealth_mode: str | bool 
             # Store subprocess so it can be terminated on quit
             driver._chrome_proc = chrome_proc  # type: ignore[attr-defined]
             driver._chrome_user_data_dir = user_data_dir  # type: ignore[attr-defined]
+            driver._proxy_ext_dir = proxy_ext_dir  # type: ignore[attr-defined]
+            driver._proxy_ext_id = proxy_ext_id  # type: ignore[attr-defined]
             _orig_quit = driver.quit
 
             def _quit_with_cleanup() -> None:
@@ -741,6 +785,9 @@ def get_webdriver(proxy: dict[str, Any] | None = None, stealth_mode: str | bool 
                     udd = getattr(driver, "_chrome_user_data_dir", None)
                     if udd and os.path.isdir(udd):
                         shutil.rmtree(udd, ignore_errors=True)
+                    ext_dir = getattr(driver, "_proxy_ext_dir", None)
+                    if ext_dir and os.path.isdir(ext_dir):
+                        shutil.rmtree(ext_dir, ignore_errors=True)
 
             driver.quit = _quit_with_cleanup  # type: ignore[method-assign]
         else:
@@ -755,6 +802,20 @@ def get_webdriver(proxy: dict[str, Any] | None = None, stealth_mode: str | bool 
                 windows_headless=windows_headless,
                 headless=get_config_headless(),
             )
+            driver._proxy_ext_dir = proxy_ext_dir  # type: ignore[attr-defined]
+            driver._proxy_ext_id = proxy_ext_id  # type: ignore[attr-defined]
+            # Wrap quit to clean up temp extension dir
+            _orig_uc_quit = driver.quit
+
+            def _uc_quit_with_cleanup() -> None:
+                try:
+                    _orig_uc_quit()
+                finally:
+                    ext_dir = getattr(driver, "_proxy_ext_dir", None)
+                    if ext_dir and os.path.isdir(ext_dir):
+                        shutil.rmtree(ext_dir, ignore_errors=True)
+
+            driver.quit = _uc_quit_with_cleanup  # type: ignore[method-assign]
     except Exception as e:
         logging.error("Error starting Chrome: %s", e)
         raise e
@@ -762,11 +823,11 @@ def get_webdriver(proxy: dict[str, Any] | None = None, stealth_mode: str | bool 
     _maybe_normalize_user_agent(driver, effective_stealth_mode)
     _maybe_apply_stealth(driver, effective_stealth_mode)
 
+    if proxy is not None:
+        apply_proxy_to_session(driver, proxy)
+
     if not custom_chromium:
         _save_patched_driver(driver, driver_exe_path)
-
-    if proxy_extension_dir is not None:
-        shutil.rmtree(proxy_extension_dir)
 
     return driver
 

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 import os
 import re
@@ -684,6 +683,8 @@ class TestFlareSolverr(unittest.TestCase):
            * sudo tinyproxy -d
            * sudo tail -f /tmp/tinyproxy.log
         """
+        hostname = urllib.parse.urlparse(self.google_url).hostname or self.google_url
+        lines_before = self._get_docker_log_line_count(self.proxy_http_container)
         res = self._request("POST", "/v1", {"cmd": "request.get", "url": self.google_url, "proxy": {"url": self.proxy_url}})
         self.assertEqual(res.status_code, 200)
 
@@ -701,6 +702,7 @@ class TestFlareSolverr(unittest.TestCase):
         self.assertIn("<title>Google</title>", solution.response)
         self.assertGreater(len(solution.cookies), 0)
         self.assertIn("Chrome/", solution.userAgent)
+        self._assert_request_routed_through_proxy(self.proxy_http_container, lines_before, hostname)
 
     def test_v1_endpoint_request_get_proxy_http_param_with_credentials(self):
         if not _proxy_reachable(self.proxy_http_check_url):
@@ -714,6 +716,8 @@ class TestFlareSolverr(unittest.TestCase):
            * sudo tinyproxy -d
            * sudo tail -f /tmp/tinyproxy.log
         """
+        hostname = urllib.parse.urlparse(self.google_url).hostname or self.google_url
+        lines_before = self._get_docker_log_line_count(self.proxy_http_container)
         res = self._request(
             "POST", "/v1", {"cmd": "request.get", "url": self.google_url, "proxy": {"url": self.proxy_url, "username": "testuser", "password": "testpass"}}
         )
@@ -733,6 +737,7 @@ class TestFlareSolverr(unittest.TestCase):
         self.assertIn("<title>Google</title>", solution.response)
         self.assertGreater(len(solution.cookies), 0)
         self.assertIn("Chrome/", solution.userAgent)
+        self._assert_request_routed_through_proxy(self.proxy_http_container, lines_before, hostname)
 
     def test_v1_endpoint_request_get_proxy_socks_param(self):
         if not _proxy_reachable(self.proxy_socks_check_url):

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,6 +1,8 @@
+import datetime
 import json
 import os
 import re
+import subprocess
 import unittest
 from typing import Optional
 
@@ -39,12 +41,12 @@ class TestFlareSolverr(unittest.TestCase):
     # Proxy URLs for tests - can be overridden via env vars
     # *_check_url: host-side address used only to verify the proxy is up before testing
     # proxy_url / proxy_socks_url: address sent to FlareSolverr (may be a Docker service name)
-    proxy_url = os.environ.get("PROXY_HTTP_URL", "http://127.0.0.1:8888")
-    proxy_url_2 = os.environ.get("PROXY_HTTP_URL_2", "http://127.0.0.1:8889")
-    proxy_socks_url = os.environ.get("PROXY_SOCKS_URL", "socks5://127.0.0.1:1080")
-    proxy_http_check_url = os.environ.get("PROXY_HTTP_CHECK_URL") or os.environ.get("PROXY_HTTP_URL", "http://127.0.0.1:8888")
-    proxy_http_check_url_2 = os.environ.get("PROXY_HTTP_CHECK_URL_2") or os.environ.get("PROXY_HTTP_URL_2", "http://127.0.0.1:8889")
-    proxy_socks_check_url = os.environ.get("PROXY_SOCKS_CHECK_URL") or os.environ.get("PROXY_SOCKS_URL", "socks5://127.0.0.1:1080")
+    proxy_url = os.environ.get("PROXY_HTTP_URL", "http://proxy-http:8888")
+    proxy_url_2 = os.environ.get("PROXY_HTTP_URL_2", "http://proxy-http-2:8888")
+    proxy_socks_url = os.environ.get("PROXY_SOCKS_URL", "socks5://proxy-socks:1080")
+    proxy_http_check_url = os.environ.get("PROXY_HTTP_CHECK_URL", "http://127.0.0.1:8888")
+    proxy_http_check_url_2 = os.environ.get("PROXY_HTTP_CHECK_URL_2", "http://127.0.0.1:8889")
+    proxy_socks_check_url = os.environ.get("PROXY_SOCKS_CHECK_URL", "socks5://127.0.0.1:1080")
     google_url = "https://www.google.com"
     are_you_a_bot_url = "https://deviceandbrowserinfo.com/are_you_a_bot"
     are_you_a_bot_interactions_url = "https://deviceandbrowserinfo.com/are_you_a_bot_interactions"
@@ -60,6 +62,58 @@ class TestFlareSolverr(unittest.TestCase):
     turnstile_workers_url = "https://browser-compat.turnstile.workers.dev/"
 
     base_url = None
+
+    # Docker container names for proxy log verification (set by docker-compose.integration.yml)
+    proxy_http_container = "flaresolverr-proxy-http-1"
+    proxy_http_2_container = "flaresolverr-proxy-http-2-1"
+
+    @staticmethod
+    def _get_docker_log_line_count(container: str) -> int:
+        """Return current line count of docker logs for container."""
+        try:
+            result = subprocess.run(
+                ["docker", "logs", container],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            return len((result.stdout + result.stderr).splitlines())
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+            return 0
+
+    @staticmethod
+    def _get_docker_logs_after(container: str, line_count: int) -> str:
+        """Return docker logs for container after a given line count."""
+        try:
+            result = subprocess.run(
+                ["docker", "logs", container],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            logs = result.stdout + result.stderr
+            lines = logs.splitlines()
+            return "\n".join(lines[line_count:])
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+            return ""
+
+    @classmethod
+    def _assert_request_routed_through_proxy(cls, container: str, line_count: int, hostname: str) -> None:
+        """Assert that a request to hostname was routed through the given proxy container."""
+        for _ in range(10):
+            logs = cls._get_docker_logs_after(container, line_count)
+            if hostname in logs:
+                return
+            time.sleep(0.5)
+        logs = cls._get_docker_logs_after(container, line_count)
+        assert hostname in logs, f"Expected request to {hostname} in {container} logs, got:\n{logs}"
+
+    @classmethod
+    def _assert_request_not_routed_through_proxy(cls, container: str, line_count: int, hostname: str) -> None:
+        """Assert that a request to hostname was NOT routed through the given proxy container."""
+        time.sleep(2)
+        logs = cls._get_docker_logs_after(container, line_count)
+        assert hostname not in logs, f"Expected NO request to {hostname} in {container} logs, but found:\n{logs}"
 
     @classmethod
     def setUpClass(cls):
@@ -1165,6 +1219,8 @@ class TestFlareSolverr(unittest.TestCase):
         if not _proxy_reachable(self.proxy_http_check_url_2):
             self.skipTest(f"Proxy 2 not reachable: {self.proxy_http_check_url_2}")
 
+        hostname = urllib.parse.urlparse(self.google_url).hostname or self.google_url
+
         # Create a session without any proxy
         self._request("POST", "/v1", {"cmd": "sessions.create", "session": "test_dynamic_proxy"})
 
@@ -1176,6 +1232,8 @@ class TestFlareSolverr(unittest.TestCase):
         assert_one_session()
 
         # Step 1: request through proxy A
+        lines_a_1 = self._get_docker_log_line_count(self.proxy_http_container)
+        lines_a_2 = self._get_docker_log_line_count(self.proxy_http_2_container)
         res = self._request(
             "POST",
             "/v1",
@@ -1191,8 +1249,12 @@ class TestFlareSolverr(unittest.TestCase):
         self.assertEqual(STATUS_OK, body.status)
         self.assertIn(self.google_url, body.solution.url)
         assert_one_session()
+        self._assert_request_routed_through_proxy(self.proxy_http_container, lines_a_1, hostname)
+        self._assert_request_not_routed_through_proxy(self.proxy_http_2_container, lines_a_2, hostname)
 
         # Step 2: switch to proxy B (different endpoint)
+        lines_b_1 = self._get_docker_log_line_count(self.proxy_http_container)
+        lines_b_2 = self._get_docker_log_line_count(self.proxy_http_2_container)
         res = self._request(
             "POST",
             "/v1",
@@ -1208,8 +1270,12 @@ class TestFlareSolverr(unittest.TestCase):
         self.assertEqual(STATUS_OK, body.status)
         self.assertIn(self.google_url, body.solution.url)
         assert_one_session()
+        self._assert_request_routed_through_proxy(self.proxy_http_2_container, lines_b_2, hostname)
+        self._assert_request_not_routed_through_proxy(self.proxy_http_container, lines_b_1, hostname)
 
         # Step 3: clear proxy (explicit empty) and request directly
+        lines_c_1 = self._get_docker_log_line_count(self.proxy_http_container)
+        lines_c_2 = self._get_docker_log_line_count(self.proxy_http_2_container)
         res = self._request(
             "POST",
             "/v1",
@@ -1225,3 +1291,5 @@ class TestFlareSolverr(unittest.TestCase):
         self.assertEqual(STATUS_OK, body.status)
         self.assertIn(self.google_url, body.solution.url)
         assert_one_session()
+        self._assert_request_not_routed_through_proxy(self.proxy_http_container, lines_c_1, hostname)
+        self._assert_request_not_routed_through_proxy(self.proxy_http_2_container, lines_c_2, hostname)

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -10,8 +10,9 @@ import requests
 from flaresolverr.dtos import IndexResponse, HealthResponse, V1ResponseBase, STATUS_OK, STATUS_ERROR
 from flaresolverr import utils
 
-import urllib.parse, socket
+import socket
 import time
+import urllib.parse
 
 pytestmark = pytest.mark.integration
 
@@ -39,8 +40,10 @@ class TestFlareSolverr(unittest.TestCase):
     # *_check_url: host-side address used only to verify the proxy is up before testing
     # proxy_url / proxy_socks_url: address sent to FlareSolverr (may be a Docker service name)
     proxy_url = os.environ.get("PROXY_HTTP_URL", "http://127.0.0.1:8888")
+    proxy_url_2 = os.environ.get("PROXY_HTTP_URL_2", "http://127.0.0.1:8889")
     proxy_socks_url = os.environ.get("PROXY_SOCKS_URL", "socks5://127.0.0.1:1080")
     proxy_http_check_url = os.environ.get("PROXY_HTTP_CHECK_URL") or os.environ.get("PROXY_HTTP_URL", "http://127.0.0.1:8888")
+    proxy_http_check_url_2 = os.environ.get("PROXY_HTTP_CHECK_URL_2") or os.environ.get("PROXY_HTTP_URL_2", "http://127.0.0.1:8889")
     proxy_socks_check_url = os.environ.get("PROXY_SOCKS_CHECK_URL") or os.environ.get("PROXY_SOCKS_URL", "socks5://127.0.0.1:1080")
     google_url = "https://www.google.com"
     are_you_a_bot_url = "https://deviceandbrowserinfo.com/are_you_a_bot"
@@ -192,10 +195,10 @@ class TestFlareSolverr(unittest.TestCase):
                 "url": self.are_you_a_bot_interactions_url,
                 "stealth": True,
                 "actions": [
-                    {"type": "wait",     "seconds": 2},
-                    {"type": "fill",     "selector": "//input[@id='email']",                                         "value": "test@example.com"},
-                    {"type": "fill",     "selector": "//input[@id='password']",                                      "value": "TestPass@123"},
-                    {"type": "click",    "selector": "//form[@id='loginForm']//button[@type='submit']"},
+                    {"type": "wait", "seconds": 2},
+                    {"type": "fill", "selector": "//input[@id='email']", "value": "test@example.com"},
+                    {"type": "fill", "selector": "//input[@id='password']", "value": "TestPass@123"},
+                    {"type": "click", "selector": "//form[@id='loginForm']//button[@type='submit']"},
                     {"type": "wait_for", "selector": "//*[contains(text(),'You are human!') or contains(text(),'You are a bot!')]"},
                 ],
             },
@@ -351,9 +354,7 @@ class TestFlareSolverr(unittest.TestCase):
         self.assertGreater(len(fairlane_cookie["value"]), 30)
 
     def test_v1_endpoint_request_get_scrapingcourse_cf_challenge(self):
-        res = self._request(
-            "POST", "/v1", {"cmd": "request.get", "url": self.scrapingcourse_cf_url, "maxTimeout": 120000}, timeout=190
-        )
+        res = self._request("POST", "/v1", {"cmd": "request.get", "url": self.scrapingcourse_cf_url, "maxTimeout": 120000}, timeout=190)
         if res.status_code == 500:
             body = V1ResponseBase(self._get_json(res))
             if "Timeout after" in body.message:
@@ -565,7 +566,15 @@ class TestFlareSolverr(unittest.TestCase):
         self.assertEqual(utils.get_flaresolverr_version(), body.version)
 
     def test_v1_endpoint_request_get_cookies_param(self):
-        res = self._request("POST", "/v1", {"cmd": "request.get", "url": self.google_url, "cookies": [{"name": "testcookie1", "value": "testvalue1"}, {"name": "testcookie2", "value": "testvalue2"}]})
+        res = self._request(
+            "POST",
+            "/v1",
+            {
+                "cmd": "request.get",
+                "url": self.google_url,
+                "cookies": [{"name": "testcookie1", "value": "testvalue1"}, {"name": "testcookie2", "value": "testvalue2"}],
+            },
+        )
         self.assertEqual(res.status_code, 200)
 
         body = V1ResponseBase(self._get_json(res))
@@ -651,7 +660,9 @@ class TestFlareSolverr(unittest.TestCase):
            * sudo tinyproxy -d
            * sudo tail -f /tmp/tinyproxy.log
         """
-        res = self._request("POST", "/v1", {"cmd": "request.get", "url": self.google_url, "proxy": {"url": self.proxy_url, "username": "testuser", "password": "testpass"}})
+        res = self._request(
+            "POST", "/v1", {"cmd": "request.get", "url": self.google_url, "proxy": {"url": self.proxy_url, "username": "testuser", "password": "testpass"}}
+        )
         self.assertEqual(res.status_code, 200)
 
         body = V1ResponseBase(self._get_json(res))
@@ -790,7 +801,9 @@ class TestFlareSolverr(unittest.TestCase):
         self.assertIn("Request parameter 'postData' or 'postDataRaw' is mandatory in 'request.post' command", body.message)
 
     def test_v1_endpoint_request_post_deprecated_param(self):
-        res = self._request("POST", "/v1", {"cmd": "request.post", "url": self.google_url, "postData": "param1=value1&param2=value2", "userAgent": "Test User-Agent"})
+        res = self._request(
+            "POST", "/v1", {"cmd": "request.post", "url": self.google_url, "postData": "param1=value1&param2=value2", "userAgent": "Test User-Agent"}
+        )
         self.assertEqual(res.status_code, 200)
 
         body = V1ResponseBase(self._get_json(res))
@@ -980,11 +993,15 @@ class TestFlareSolverr(unittest.TestCase):
         self._request("POST", "/v1", {"cmd": "sessions.create", "session": "test_eval_session"})
         self._request("POST", "/v1", {"cmd": "request.get", "session": "test_eval_session", "url": self.google_url})
 
-        res = self._request("POST", "/v1", {
-            "cmd": "sessions.eval",
-            "session": "test_eval_session",
-            "script": "return document.title",
-        })
+        res = self._request(
+            "POST",
+            "/v1",
+            {
+                "cmd": "sessions.eval",
+                "session": "test_eval_session",
+                "script": "return document.title",
+            },
+        )
         self.assertEqual(res.status_code, 200)
 
         body = V1ResponseBase(self._get_json(res))
@@ -996,7 +1013,8 @@ class TestFlareSolverr(unittest.TestCase):
     def test_v1_endpoint_sessions_eval_missing_script(self):
         self._request("POST", "/v1", {"cmd": "sessions.create", "session": "test_eval_no_script"})
         res = self._request(
-            "POST", "/v1",
+            "POST",
+            "/v1",
             {"cmd": "sessions.eval", "session": "test_eval_no_script"},
             status=500,
         )
@@ -1028,11 +1046,15 @@ class TestFlareSolverr(unittest.TestCase):
         self._request("POST", "/v1", {"cmd": "sessions.create", "session": "test_click_session"})
         self._request("POST", "/v1", {"cmd": "request.get", "session": "test_click_session", "url": self.google_url})
 
-        res = self._request("POST", "/v1", {
-            "cmd": "sessions.click",
-            "session": "test_click_session",
-            "selector": "//a[contains(text(),'Gmail')] | //a[@aria-label='Gmail']",
-        })
+        res = self._request(
+            "POST",
+            "/v1",
+            {
+                "cmd": "sessions.click",
+                "session": "test_click_session",
+                "selector": "//a[contains(text(),'Gmail')] | //a[@aria-label='Gmail']",
+            },
+        )
         self.assertEqual(res.status_code, 200)
 
         body = V1ResponseBase(self._get_json(res))
@@ -1044,11 +1066,16 @@ class TestFlareSolverr(unittest.TestCase):
         self._request("POST", "/v1", {"cmd": "sessions.create", "session": "test_click_missing"})
         self._request("POST", "/v1", {"cmd": "request.get", "session": "test_click_missing", "url": self.google_url})
 
-        res = self._request("POST", "/v1", {
-            "cmd": "sessions.click",
-            "session": "test_click_missing",
-            "selector": "//span[@id='nonexistent-span-12345']",
-        }, status=500)
+        res = self._request(
+            "POST",
+            "/v1",
+            {
+                "cmd": "sessions.click",
+                "session": "test_click_missing",
+                "selector": "//span[@id='nonexistent-span-12345']",
+            },
+            status=500,
+        )
         self.assertEqual(res.status_code, 500)
 
         body = V1ResponseBase(self._get_json(res))
@@ -1060,15 +1087,19 @@ class TestFlareSolverr(unittest.TestCase):
         self._request("POST", "/v1", {"cmd": "sessions.create", "session": "test_action_session"})
         self._request("POST", "/v1", {"cmd": "request.get", "session": "test_action_session", "url": self.google_url})
 
-        res = self._request("POST", "/v1", {
-            "cmd": "sessions.action",
-            "session": "test_action_session",
-            "actions": [
-                {"type": "wait", "seconds": 1},
-                {"type": "click", "selector": "//a[contains(text(),'Gmail')] | //a[@aria-label='Gmail']"},
-                {"type": "wait", "seconds": 1},
-            ],
-        })
+        res = self._request(
+            "POST",
+            "/v1",
+            {
+                "cmd": "sessions.action",
+                "session": "test_action_session",
+                "actions": [
+                    {"type": "wait", "seconds": 1},
+                    {"type": "click", "selector": "//a[contains(text(),'Gmail')] | //a[@aria-label='Gmail']"},
+                    {"type": "wait", "seconds": 1},
+                ],
+            },
+        )
         self.assertEqual(res.status_code, 200)
 
         body = V1ResponseBase(self._get_json(res))
@@ -1079,7 +1110,8 @@ class TestFlareSolverr(unittest.TestCase):
     def test_v1_endpoint_sessions_action_missing_actions(self):
         self._request("POST", "/v1", {"cmd": "sessions.create", "session": "test_action_missing"})
         res = self._request(
-            "POST", "/v1",
+            "POST",
+            "/v1",
             {"cmd": "sessions.action", "session": "test_action_missing"},
             status=500,
         )
@@ -1094,13 +1126,17 @@ class TestFlareSolverr(unittest.TestCase):
         self._request("POST", "/v1", {"cmd": "sessions.create", "session": "test_eval_session"})
         self._request("POST", "/v1", {"cmd": "request.get", "session": "test_eval_session", "url": self.google_url})
 
-        res = self._request("POST", "/v1", {
-            "cmd": "sessions.action",
-            "session": "test_eval_session",
-            "actions": [
-                {"type": "eval", "script": "return document.title"},
-            ],
-        })
+        res = self._request(
+            "POST",
+            "/v1",
+            {
+                "cmd": "sessions.action",
+                "session": "test_eval_session",
+                "actions": [
+                    {"type": "eval", "script": "return document.title"},
+                ],
+            },
+        )
         self.assertEqual(res.status_code, 200)
 
         body = V1ResponseBase(self._get_json(res))
@@ -1121,3 +1157,71 @@ class TestFlareSolverr(unittest.TestCase):
         self.assertIsNotNone(body.solution.screenshot)
         self.assertGreater(len(body.solution.screenshot), 100)
         self.assertIn(self.google_url, body.solution.url)
+
+    def test_v1_endpoint_session_dynamic_proxy_switch(self):
+        """Dynamic proxy switching and clearing on a reused session."""
+        if not _proxy_reachable(self.proxy_http_check_url):
+            self.skipTest(f"Proxy not reachable: {self.proxy_http_check_url}")
+        if not _proxy_reachable(self.proxy_http_check_url_2):
+            self.skipTest(f"Proxy 2 not reachable: {self.proxy_http_check_url_2}")
+
+        # Create a session without any proxy
+        self._request("POST", "/v1", {"cmd": "sessions.create", "session": "test_dynamic_proxy"})
+
+        def assert_one_session():
+            list_res = self._request("POST", "/v1", {"cmd": "sessions.list"})
+            list_body = self._get_json(list_res)
+            self.assertEqual(len(list_body["sessions"]), 1)
+
+        assert_one_session()
+
+        # Step 1: request through proxy A
+        res = self._request(
+            "POST",
+            "/v1",
+            {
+                "cmd": "request.get",
+                "session": "test_dynamic_proxy",
+                "url": self.google_url,
+                "proxy": {"url": self.proxy_url},
+            },
+        )
+        self.assertEqual(res.status_code, 200)
+        body = V1ResponseBase(self._get_json(res))
+        self.assertEqual(STATUS_OK, body.status)
+        self.assertIn(self.google_url, body.solution.url)
+        assert_one_session()
+
+        # Step 2: switch to proxy B (different endpoint)
+        res = self._request(
+            "POST",
+            "/v1",
+            {
+                "cmd": "request.get",
+                "session": "test_dynamic_proxy",
+                "url": self.google_url,
+                "proxy": {"url": self.proxy_url_2},
+            },
+        )
+        self.assertEqual(res.status_code, 200)
+        body = V1ResponseBase(self._get_json(res))
+        self.assertEqual(STATUS_OK, body.status)
+        self.assertIn(self.google_url, body.solution.url)
+        assert_one_session()
+
+        # Step 3: clear proxy (explicit empty) and request directly
+        res = self._request(
+            "POST",
+            "/v1",
+            {
+                "cmd": "request.get",
+                "session": "test_dynamic_proxy",
+                "url": self.google_url,
+                "proxy": {"url": ""},
+            },
+        )
+        self.assertEqual(res.status_code, 200)
+        body = V1ResponseBase(self._get_json(res))
+        self.assertEqual(STATUS_OK, body.status)
+        self.assertIn(self.google_url, body.solution.url)
+        assert_one_session()

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -12,12 +12,23 @@ class DummyDriver:
     def __init__(self) -> None:
         self.closed = 0
         self.quitted = 0
+        self.current_url = "about:blank"
+        self._proxy_ext_id = "abc123"
 
     def close(self) -> None:
         self.closed += 1
 
     def quit(self) -> None:
         self.quitted += 1
+
+    def execute_script(self, script: str):
+        # Simulate extension-page ACK polling
+        if "chrome.runtime.sendMessage" in script:
+            return None
+        return {"success": True}
+
+    def get(self, url: str) -> None:
+        self.current_url = url
 
 
 def test_session_lifetime_is_timedelta() -> None:
@@ -310,3 +321,91 @@ def test_destroy_verifies_browser_pid_dead(monkeypatch) -> None:
     storage.create("verify-pid")
     storage.destroy("verify-pid")
     assert verified["called"] is True
+
+
+def test_create_stores_proxy_on_session(monkeypatch) -> None:
+    storage = sessions.SessionsStorage()
+    monkeypatch.setattr(sessions.utils, "get_webdriver", lambda _proxy, stealth_mode=None, logging_prefs=None: DummyDriver())
+
+    session, _ = storage.create("s1", proxy={"url": "http://proxy:8080"})
+    assert session.proxy == {"url": "http://proxy:8080"}
+
+
+def test_reuse_updates_proxy_when_changed(monkeypatch) -> None:
+    storage = sessions.SessionsStorage()
+    applied: list[dict | None] = []
+
+    monkeypatch.setattr(sessions.utils, "get_webdriver", lambda _proxy, stealth_mode=None, logging_prefs=None: DummyDriver())
+    monkeypatch.setattr(sessions.utils, "apply_proxy_to_session", lambda driver, proxy: applied.append(proxy))
+
+    storage.create("s1", proxy={"url": "http://proxy1:8080"})
+    storage.create("s1", proxy={"url": "http://proxy2:8080"})
+
+    assert len(applied) == 1
+    assert applied[0] == {"url": "http://proxy2:8080"}
+
+
+def test_reuse_clears_proxy_with_empty(monkeypatch) -> None:
+    storage = sessions.SessionsStorage()
+    applied: list[dict | None] = []
+
+    monkeypatch.setattr(sessions.utils, "get_webdriver", lambda _proxy, stealth_mode=None, logging_prefs=None: DummyDriver())
+    monkeypatch.setattr(sessions.utils, "apply_proxy_to_session", lambda driver, proxy: applied.append(proxy))
+
+    storage.create("s1", proxy={"url": "http://proxy:8080"})
+    storage.create("s1", proxy={"url": ""})
+
+    assert len(applied) == 1
+    assert applied[0] == {"url": ""}
+
+
+def test_reuse_keeps_proxy_when_omitted(monkeypatch) -> None:
+    storage = sessions.SessionsStorage()
+    applied: list[dict | None] = []
+
+    monkeypatch.setattr(sessions.utils, "get_webdriver", lambda _proxy, stealth_mode=None, logging_prefs=None: DummyDriver())
+    monkeypatch.setattr(sessions.utils, "apply_proxy_to_session", lambda driver, proxy: applied.append(proxy))
+
+    storage.create("s1", proxy={"url": "http://proxy:8080"})
+    storage.create("s1")  # no proxy argument
+
+    assert len(applied) == 0
+
+
+def test_reuse_skips_proxy_update_when_same(monkeypatch) -> None:
+    storage = sessions.SessionsStorage()
+    applied: list[dict | None] = []
+
+    monkeypatch.setattr(sessions.utils, "get_webdriver", lambda _proxy, stealth_mode=None, logging_prefs=None: DummyDriver())
+    monkeypatch.setattr(sessions.utils, "apply_proxy_to_session", lambda driver, proxy: applied.append(proxy))
+
+    storage.create("s1", proxy={"url": "http://proxy:8080"})
+    storage.create("s1", proxy={"url": "http://proxy:8080"})
+
+    assert len(applied) == 0
+
+
+def test_reuse_updates_proxy_when_auth_changes(monkeypatch) -> None:
+    """Regression: same URL but different credentials must trigger an update."""
+    storage = sessions.SessionsStorage()
+    applied: list[dict | None] = []
+
+    monkeypatch.setattr(sessions.utils, "get_webdriver", lambda _proxy, stealth_mode=None, logging_prefs=None: DummyDriver())
+    monkeypatch.setattr(sessions.utils, "apply_proxy_to_session", lambda driver, proxy: applied.append(proxy))
+
+    storage.create("s1", proxy={"url": "http://proxy:8080", "username": "user1", "password": "pass1"})
+    storage.create("s1", proxy={"url": "http://proxy:8080", "username": "user2", "password": "pass2"})
+
+    assert len(applied) == 1
+    assert applied[0]["username"] == "user2"
+
+
+def test_reuse_raises_on_invalid_proxy(monkeypatch) -> None:
+    """Invalid proxy on a reused session must raise RuntimeError (not silently keep old proxy)."""
+    storage = sessions.SessionsStorage()
+
+    monkeypatch.setattr(sessions.utils, "get_webdriver", lambda _proxy, stealth_mode=None, logging_prefs=None: DummyDriver())
+
+    storage.create("s1", proxy={"url": "http://proxy:8080"})
+    with pytest.raises(RuntimeError, match="schema required"):
+        storage.create("s1", proxy={"url": "proxy:8080"})

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,3 +1,6 @@
+import json
+from unittest.mock import MagicMock
+
 import pytest
 
 from flaresolverr import utils
@@ -36,3 +39,108 @@ def test_sanitize_user_agent_keeps_regular_user_agent():
 )
 def test_is_binary_content_type(content_type, expected):
     assert utils.is_binary_content_type(content_type) is expected
+
+
+def _make_ack_driver(ext_id: str = "abc123") -> MagicMock:
+    """Return a MagicMock driver that simulates extension-page ACK polling."""
+    driver = MagicMock()
+    driver.current_url = "about:blank"
+    driver._proxy_ext_id = ext_id
+
+    def fake_get(url: str) -> None:
+        driver.current_url = url
+
+    driver.get = MagicMock(side_effect=fake_get)
+
+    def fake_execute(script: str):
+        if "chrome.runtime.id" in script:
+            return ext_id
+        if "chrome.runtime.sendMessage" in script:
+            return None
+        # polling for result
+        return {"success": True}
+
+    driver.execute_script = MagicMock(side_effect=fake_execute)
+    return driver
+
+
+def test_apply_proxy_to_session_navigates_to_extension_page(monkeypatch) -> None:
+    """It should navigate to the extension's proxy.html page."""
+    driver = _make_ack_driver("abc123")
+    monkeypatch.setattr(utils, "_check_proxy_reachable", lambda url: None)
+
+    utils.apply_proxy_to_session(driver, {"url": "http://proxy:8080"})
+
+    driver.get.assert_called_once_with("chrome-extension://abc123/proxy.html")
+
+
+def test_apply_proxy_to_session_uses_chrome_runtime_sendmessage(monkeypatch) -> None:
+    """apply_proxy_to_session should use chrome.runtime.sendMessage from the extension page."""
+    driver = _make_ack_driver("abc123")
+    monkeypatch.setattr(utils, "_check_proxy_reachable", lambda url: None)
+
+    utils.apply_proxy_to_session(driver, {"url": "http://proxy:8080"})
+
+    injected = [c[0][0] for c in driver.execute_script.call_args_list if "chrome.runtime.sendMessage" in c[0][0]]
+    assert len(injected) == 1
+    assert '"mode": "fixed_servers"' in injected[0]
+
+
+def test_apply_proxy_to_session_sends_direct_for_empty_proxy(monkeypatch) -> None:
+    """Passing an empty proxy should send mode=direct to the extension."""
+    driver = _make_ack_driver("abc123")
+
+    utils.apply_proxy_to_session(driver, {"url": ""})
+
+    injected = [c[0][0] for c in driver.execute_script.call_args_list if "chrome.runtime.sendMessage" in c[0][0]]
+    assert len(injected) == 1
+    assert '"mode": "direct"' in injected[0]
+
+
+def test_apply_proxy_to_session_sends_auth_when_present(monkeypatch) -> None:
+    """Authenticated proxies should include auth credentials in the payload."""
+    driver = _make_ack_driver("abc123")
+    monkeypatch.setattr(utils, "_check_proxy_reachable", lambda url: None)
+
+    utils.apply_proxy_to_session(
+        driver, {"url": "http://proxy:8080", "username": "user", "password": "pass"}
+    )
+
+    injected = [c[0][0] for c in driver.execute_script.call_args_list if "chrome.runtime.sendMessage" in c[0][0]]
+    assert len(injected) == 1
+    script = injected[0]
+    assert '"username": "user"' in script
+    assert '"password": "pass"' in script
+    assert '"mode": "fixed_servers"' in script
+
+
+def test_apply_proxy_to_session_raises_on_invalid_proxy() -> None:
+    """An invalid proxy (missing schema) must raise RuntimeError."""
+    driver = _make_ack_driver("abc123")
+    with pytest.raises(RuntimeError, match="schema required"):
+        utils.apply_proxy_to_session(driver, {"url": "proxy:8080"})
+
+
+def test_apply_proxy_to_session_raises_on_extension_failure(monkeypatch) -> None:
+    """If the extension reports failure, we must raise."""
+    driver = MagicMock()
+    driver.current_url = "about:blank"
+    driver._proxy_ext_id = "abc123"
+
+    def fake_get(url: str) -> None:
+        driver.current_url = url
+
+    driver.get = MagicMock(side_effect=fake_get)
+
+    def fake_execute(script: str):
+        if "chrome.runtime.id" in script:
+            return "abc123"
+        if "chrome.runtime.sendMessage" in script:
+            return None
+        return {"success": False, "error": "bg error"}
+
+    driver.execute_script = fake_execute
+    monkeypatch.setattr(utils, "_check_proxy_reachable", lambda url: None)
+
+    with pytest.raises(RuntimeError, match="bg error"):
+        utils.apply_proxy_to_session(driver, {"url": "http://proxy:8080"})

--- a/whitelist.py
+++ b/whitelist.py
@@ -11,6 +11,7 @@ from flaresolverr.client.models import ChallengeSolution
 from flaresolverr.dtos import ChallengeResolutionResultT
 from flaresolverr.sessions import SessionsStorage
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.remote.webdriver import WebDriver
 
 # Public _SessionManager API methods (called by users of the client library)
 _SessionManager.cdp
@@ -42,3 +43,6 @@ SessionsStorage.stop_cleanup
 
 # Attribute set on driver options by undetected_chromedriver
 Options.binary_location
+
+# Proxy extension attributes stored on WebDriver instances
+WebDriver._proxy_ext_id


### PR DESCRIPTION
- Add Chrome MV3 extension (background.js, proxy.html) for runtime proxy changes
- Extension uses chrome.proxy.settings.set with ACK from callback
- Auth stored in module-level currentAuth to avoid storage race
- Navigate to chrome-extension://<id>/proxy.html for stable command channel
- Add _compute_extension_id() with live chrome.runtime.id smoke check
- Remove dead content_script.js and token randomization
- Invalid proxy configs now raise RuntimeError on fresh AND reused sessions
- Proxy clearing via empty {"url": ""} works on reused sessions
- Full proxy dict comparison catches auth-only changes on reuse
- Add proxy_http_2 to docker-compose.integration.yml
- Add integration test verifying switch + clear on same session
- Add unit tests for ACK failure, invalid proxy, auth change detection