### PR TITLE
fix(patcher): skip __del__ binary cleanup and recover missing binary (all platforms)

### DIFF
--- a/src/flaresolverr/undetected_chromedriver/patcher.py
+++ b/src/flaresolverr/undetected_chromedriver/patcher.py
@@ -439,30 +439,8 @@ class Patcher(object):
         )
 
     def __del__(self):
-        if self._custom_exe_path:
-            # if the driver binary is specified by user
-            # we assume it is important enough to not delete it
-            return
-        if self.platform_name == "freebsd":
-            # On FreeBSD the patched binary is copied from the system
-            # chromedriver (not downloaded fresh each time).  Keep it
-            # between sessions so concurrent/sequential Patcher instances
-            # don't race on a missing file (issue #82).
-            return
-        else:
-            timeout = 3  # stop trying after this many seconds
-            t = time.monotonic()
-            now = lambda: time.monotonic()
-            while now() - t < timeout:
-                # we don't want to wait until the end of time
-                try:
-                    if self.user_multi_procs:
-                        break
-                    os.unlink(self.executable_path)
-                    logger.debug("successfully unlinked %s" % self.executable_path)
-                    break
-                except FileNotFoundError:
-                    break
-                except (OSError, RuntimeError, PermissionError):
-                    time.sleep(0.01)
-                    continue
+        # The patched binary is reused between sessions (via version.txt on
+        # FreeBSD and via PATCHED_DRIVER_PATH on all platforms).  Deleting it
+        # in __del__ causes a race condition where the next Patcher instance
+        # finds the file missing (issue #82).
+        return

--- a/src/flaresolverr/undetected_chromedriver/patcher.py
+++ b/src/flaresolverr/undetected_chromedriver/patcher.py
@@ -163,11 +163,17 @@ class Patcher(object):
             # The CDC aliases are already removed at source level (C++ Patch 10).
             if os.path.exists("/opt/chromium/.stealth-patched"):
                 return True
-            ispatched = self.is_binary_patched(self.executable_path)
-            if not ispatched:
-                return self.patch_exe()
+            if not os.path.isfile(self.executable_path):
+                # The cached patched binary is missing (e.g. deleted by a
+                # previous Patcher.__del__).  Fall through to the normal
+                # copy/download + patch logic to recover.
+                self._custom_exe_path = False
             else:
-                return True
+                ispatched = self.is_binary_patched(self.executable_path)
+                if not ispatched:
+                    return self.patch_exe()
+                else:
+                    return True
 
         if version_main:
             self.version_main = version_main
@@ -436,6 +442,12 @@ class Patcher(object):
         if self._custom_exe_path:
             # if the driver binary is specified by user
             # we assume it is important enough to not delete it
+            return
+        if self.platform_name == "freebsd":
+            # On FreeBSD the patched binary is copied from the system
+            # chromedriver (not downloaded fresh each time).  Keep it
+            # between sessions so concurrent/sequential Patcher instances
+            # don't race on a missing file (issue #82).
             return
         else:
             timeout = 3  # stop trying after this many seconds

--- a/tests/unit/test_undetected_chromedriver_patcher.py
+++ b/tests/unit/test_undetected_chromedriver_patcher.py
@@ -1,7 +1,6 @@
 import gc
 import os
-import posixpath
-import tempfile
+import shutil
 from pathlib import Path
 
 import pytest
@@ -30,98 +29,70 @@ fi
 
 def _hide_stealth_marker(monkeypatch):
     """Ensure /opt/chromium/.stealth-patched is seen as absent (dev machines may have it)."""
-    _real = posixpath.exists
+    _real = os.path.exists
     monkeypatch.setattr("os.path.exists", lambda p: False if p == _STEALTH_MARKER else _real(p))
 
 
-def _make_freebsd_patcher(data_path: str, version_main: int = 148, executable_path: str | None = None) -> Patcher:
+def _make_patcher(data_path: str, version_main: int = 148, executable_path: str | None = None, platform_name: str | None = None) -> Patcher:
     p = Patcher(version_main=version_main)
-    # Force the FreeBSD code path against an isolated data directory.
-    p.platform = "freebsd15"
-    p.platform_name = "freebsd"
     p.data_path = data_path
     p.executable_path = executable_path or os.path.join(data_path, "chromedriver")
     p._custom_exe_path = executable_path is not None
+    if platform_name:
+        p.platform_name = platform_name
+        p.platform = platform_name
     return p
 
 
-def test_freebsd_patcher_recovers_when_patched_binary_deleted(monkeypatch, tmp_path):
-    """Regression test for issue #82.
+def _setup_patched_binary(patcher: Patcher, fake_chromedriver: Path) -> None:
+    """Copy and patch a fake chromedriver into the patcher's executable_path."""
+    shutil.copy(fake_chromedriver, patcher.executable_path)
+    os.chmod(patcher.executable_path, 0o755)
+    patcher.patch_exe()
 
-    Patcher.__del__ now deletes the patched chromedriver binary.  On FreeBSD,
-    auto() must re-copy the system chromedriver when the cached binary is
-    missing, even if version.txt is still up-to-date.  Otherwise the next
-    session fails with FileNotFoundError.
+
+def test_del_does_not_delete_binary(monkeypatch, tmp_path):
+    """Patcher.__del__ must not delete the patched binary on any platform.
+
+    The patched binary is reused between sessions (via version.txt on FreeBSD
+    and via PATCHED_DRIVER_PATH on all platforms).  Deleting it in __del__
+    causes a race condition where the next Patcher instance finds the file
+    missing (issue #82).
     """
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
-    _make_fake_chromedriver(bin_dir)
-    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+    _hide_stealth_marker(monkeypatch)
 
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     data_path = str(data_dir)
 
-    _hide_stealth_marker(monkeypatch)
+    fake = _make_fake_chromedriver(tmp_path)
 
-    p1 = _make_freebsd_patcher(data_path)
-    assert p1.auto() is True
-    exe_path = p1.executable_path
-    assert os.path.exists(exe_path)
-    assert p1.is_binary_patched(exe_path)
-
-    # Simulate the cleanup that Patcher.__del__ performs after the driver is
-    # closed: the patched binary is removed but version.txt remains.
-    os.unlink(exe_path)
-    assert os.path.exists(os.path.join(data_path, "version.txt"))
-
-    p2 = _make_freebsd_patcher(data_path)
-    assert p2.auto() is True
-    assert os.path.exists(p2.executable_path)
-    assert p2.is_binary_patched(p2.executable_path)
-
-
-def test_freebsd_del_does_not_delete_binary(monkeypatch, tmp_path):
-    """Patcher.__del__ must not delete the patched binary on FreeBSD.
-
-    The binary is copied from the system chromedriver (not downloaded fresh
-    each time).  Deleting it between sessions causes a race condition where
-    the next Patcher instance finds the file missing (issue #82 follow-up).
-    """
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
-    _make_fake_chromedriver(bin_dir)
-    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
-
-    data_dir = tmp_path / "data"
-    data_dir.mkdir()
-    data_path = str(data_dir)
-
-    _hide_stealth_marker(monkeypatch)
-
-    p = _make_freebsd_patcher(data_path)
-    assert p.auto() is True
+    p = _make_patcher(data_path)
+    _setup_patched_binary(p, fake)
     exe_path = p.executable_path
     assert os.path.exists(exe_path)
+    assert p.is_binary_patched(exe_path)
 
     # Trigger __del__ — the binary must survive.
     del p
     gc.collect()
-    assert os.path.exists(exe_path), "__del__ deleted the patched binary on FreeBSD"
+    assert os.path.exists(exe_path), "__del__ deleted the patched binary"
 
 
-def test_freebsd_auto_recovers_with_custom_exe_path_when_file_missing(monkeypatch, tmp_path):
-    """Regression test for issue #82 follow-up: race condition.
+def test_auto_recovers_with_custom_exe_path_when_file_missing(monkeypatch, tmp_path):
+    """Regression test for issue #82: _custom_exe_path recovery.
 
     After the startup test, _save_patched_driver sets PATCHED_DRIVER_PATH.
     On the next request, Patcher is created with _custom_exe_path=True.
-    If the binary was deleted by a previous __del__, auto() must fall
-    through to the copy logic instead of calling patch_exe() on a
+    If the binary is missing, auto() must fall through to the normal
+    copy/download + patch logic instead of calling patch_exe() on a
     non-existent file.
     """
+    _hide_stealth_marker(monkeypatch)
+
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
-    _make_fake_chromedriver(bin_dir)
+    fake = _make_fake_chromedriver(bin_dir)
     monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
 
     data_dir = tmp_path / "data"
@@ -129,20 +100,52 @@ def test_freebsd_auto_recovers_with_custom_exe_path_when_file_missing(monkeypatc
     data_path = str(data_dir)
     exe_path = os.path.join(data_path, "chromedriver")
 
-    _hide_stealth_marker(monkeypatch)
-
     # Simulate the startup test: patcher with _custom_exe_path=False.
-    p1 = _make_freebsd_patcher(data_path)
+    p1 = _make_patcher(data_path, platform_name="freebsd")
     assert p1.auto() is True
     assert os.path.exists(exe_path)
 
-    # Simulate a previous __del__ deleting the binary (pre-fix behaviour).
+    # Simulate the binary being deleted (e.g. by a previous __del__ before fix).
     os.unlink(exe_path)
 
     # Simulate the first request: PATCHED_DRIVER_PATH is set, so the patcher
     # gets _custom_exe_path=True pointing at the same path.
-    p2 = _make_freebsd_patcher(data_path, executable_path=exe_path)
+    p2 = _make_patcher(data_path, executable_path=exe_path, platform_name="freebsd")
     assert p2._custom_exe_path is True
+    assert p2.auto() is True
+    assert os.path.exists(p2.executable_path)
+    assert p2.is_binary_patched(p2.executable_path)
+
+
+def test_freebsd_patcher_recovers_when_patched_binary_deleted(monkeypatch, tmp_path):
+    """Regression test for issue #82: FreeBSD version.txt recovery.
+
+    On FreeBSD, auto() must re-copy the system chromedriver when the cached
+    binary is missing, even if version.txt is still up-to-date.  Otherwise
+    the next session fails with FileNotFoundError.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _make_fake_chromedriver(bin_dir)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    data_path = str(data_dir)
+
+    _hide_stealth_marker(monkeypatch)
+
+    p1 = _make_patcher(data_path, platform_name="freebsd")
+    assert p1.auto() is True
+    exe_path = p1.executable_path
+    assert os.path.exists(exe_path)
+    assert p1.is_binary_patched(exe_path)
+
+    # Simulate the binary being removed while version.txt remains.
+    os.unlink(exe_path)
+    assert os.path.exists(os.path.join(data_path, "version.txt"))
+
+    p2 = _make_patcher(data_path, platform_name="freebsd")
     assert p2.auto() is True
     assert os.path.exists(p2.executable_path)
     assert p2.is_binary_patched(p2.executable_path)

--- a/tests/unit/test_undetected_chromedriver_patcher.py
+++ b/tests/unit/test_undetected_chromedriver_patcher.py
@@ -1,10 +1,14 @@
+import gc
 import os
+import posixpath
 import tempfile
 from pathlib import Path
 
 import pytest
 
 from flaresolverr.undetected_chromedriver.patcher import Patcher
+
+_STEALTH_MARKER = "/opt/chromium/.stealth-patched"
 
 
 def _make_fake_chromedriver(bin_dir: Path) -> Path:
@@ -24,14 +28,20 @@ fi
     return fake
 
 
-def _make_freebsd_patcher(data_path: str, version_main: int = 148) -> Patcher:
+def _hide_stealth_marker(monkeypatch):
+    """Ensure /opt/chromium/.stealth-patched is seen as absent (dev machines may have it)."""
+    _real = posixpath.exists
+    monkeypatch.setattr("os.path.exists", lambda p: False if p == _STEALTH_MARKER else _real(p))
+
+
+def _make_freebsd_patcher(data_path: str, version_main: int = 148, executable_path: str | None = None) -> Patcher:
     p = Patcher(version_main=version_main)
     # Force the FreeBSD code path against an isolated data directory.
     p.platform = "freebsd15"
     p.platform_name = "freebsd"
     p.data_path = data_path
-    p.executable_path = os.path.join(data_path, "chromedriver")
-    p._custom_exe_path = False
+    p.executable_path = executable_path or os.path.join(data_path, "chromedriver")
+    p._custom_exe_path = executable_path is not None
     return p
 
 
@@ -52,6 +62,8 @@ def test_freebsd_patcher_recovers_when_patched_binary_deleted(monkeypatch, tmp_p
     data_dir.mkdir()
     data_path = str(data_dir)
 
+    _hide_stealth_marker(monkeypatch)
+
     p1 = _make_freebsd_patcher(data_path)
     assert p1.auto() is True
     exe_path = p1.executable_path
@@ -64,6 +76,73 @@ def test_freebsd_patcher_recovers_when_patched_binary_deleted(monkeypatch, tmp_p
     assert os.path.exists(os.path.join(data_path, "version.txt"))
 
     p2 = _make_freebsd_patcher(data_path)
+    assert p2.auto() is True
+    assert os.path.exists(p2.executable_path)
+    assert p2.is_binary_patched(p2.executable_path)
+
+
+def test_freebsd_del_does_not_delete_binary(monkeypatch, tmp_path):
+    """Patcher.__del__ must not delete the patched binary on FreeBSD.
+
+    The binary is copied from the system chromedriver (not downloaded fresh
+    each time).  Deleting it between sessions causes a race condition where
+    the next Patcher instance finds the file missing (issue #82 follow-up).
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _make_fake_chromedriver(bin_dir)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    data_path = str(data_dir)
+
+    _hide_stealth_marker(monkeypatch)
+
+    p = _make_freebsd_patcher(data_path)
+    assert p.auto() is True
+    exe_path = p.executable_path
+    assert os.path.exists(exe_path)
+
+    # Trigger __del__ — the binary must survive.
+    del p
+    gc.collect()
+    assert os.path.exists(exe_path), "__del__ deleted the patched binary on FreeBSD"
+
+
+def test_freebsd_auto_recovers_with_custom_exe_path_when_file_missing(monkeypatch, tmp_path):
+    """Regression test for issue #82 follow-up: race condition.
+
+    After the startup test, _save_patched_driver sets PATCHED_DRIVER_PATH.
+    On the next request, Patcher is created with _custom_exe_path=True.
+    If the binary was deleted by a previous __del__, auto() must fall
+    through to the copy logic instead of calling patch_exe() on a
+    non-existent file.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _make_fake_chromedriver(bin_dir)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    data_path = str(data_dir)
+    exe_path = os.path.join(data_path, "chromedriver")
+
+    _hide_stealth_marker(monkeypatch)
+
+    # Simulate the startup test: patcher with _custom_exe_path=False.
+    p1 = _make_freebsd_patcher(data_path)
+    assert p1.auto() is True
+    assert os.path.exists(exe_path)
+
+    # Simulate a previous __del__ deleting the binary (pre-fix behaviour).
+    os.unlink(exe_path)
+
+    # Simulate the first request: PATCHED_DRIVER_PATH is set, so the patcher
+    # gets _custom_exe_path=True pointing at the same path.
+    p2 = _make_freebsd_patcher(data_path, executable_path=exe_path)
+    assert p2._custom_exe_path is True
     assert p2.auto() is True
     assert os.path.exists(p2.executable_path)
     assert p2.is_binary_patched(p2.executable_path)


### PR DESCRIPTION
## Follow-up to #88 (issue #82)

PR #88 fixed the FreeBSD  re-copy when the cached binary was missing. However, the follow-up comment on #82 showed the **first request still fails** after a successful startup test.

### Root cause: race condition with `Patcher.__del__`

1. **Startup test**: `Patcher` (with `_custom_exe_path=False`) copies and patches the binary. `_save_patched_driver` sets `PATCHED_DRIVER_PATH` to the same path.
2. **Startup test cleanup**: `Patcher.__del__` runs with `_custom_exe_path=False` → **deletes** `~/.undetected_chromedriver/chromedriver`.
3. **First request**: `PATCHED_DRIVER_PATH` is now set → new `Patcher` gets `_custom_exe_path=True` → `is_binary_patched()` returns `False` (file deleted) → `patch_exe()` → **FileNotFoundError**.

This affects **all platforms**, not just FreeBSD — `PATCHED_DRIVER_PATH` is set on Linux/Darwin too.

### Fix (two parts)

1. **`Patcher.__del__`**: Skip binary cleanup on **all platforms**. The patched binary is reused between sessions (via `version.txt` on FreeBSD and via `PATCHED_DRIVER_PATH` on all platforms). Deleting it in `__del__` causes the race condition.

2. **`Patcher.auto()`**: When `_custom_exe_path=True` but the file is missing, fall through to the normal copy/download + patch logic instead of calling `patch_exe()` on a non-existent file. This handles recovery from any prior deletion.

### Tests

- `test_del_does_not_delete_binary` — generic: `__del__` preserves the binary on any platform
- `test_auto_recovers_with_custom_exe_path_when_file_missing` — `_custom_exe_path` fall-through recovery
- `test_freebsd_patcher_recovers_when_patched_binary_deleted` — FreeBSD `version.txt` re-copy (from #88)

Fixes #82