### PR TITLE
fix(sessions): kill entire Chrome process group on session destroy

### DIFF
--- a/src/flaresolverr/sessions.py
+++ b/src/flaresolverr/sessions.py
@@ -39,6 +39,47 @@ def _process_alive(pid: int) -> bool:
     return True
 
 
+def _kill_process_tree(pid: int, sig: int) -> None:
+    """Kill a process and all children in its process group.
+
+    Chrome is started with ``start_new_session=True`` (setsid), so its
+    PGID == PID.  Killing the entire group is critical on FreeBSD where
+    Chrome child processes (renderer, GPU, etc.) don't auto-die when the
+    parent is killed — FreeBSD lacks ``prctl(PR_SET_PDEATHSIG)`` — so
+    they would otherwise become orphaned and leak (issue #90).
+    """
+    if utils.PLATFORM_VERSION == "nt":
+        try:
+            subprocess.run(  # nosec
+                ["taskkill", "/F", "/PID", str(pid), "/T"],
+                check=False,
+                capture_output=True,
+            )
+        except Exception:  # nosec B110
+            pass
+        return
+
+    # On POSIX, try to kill the entire process group if the process is
+    # a group leader (started with setsid/start_new_session).
+    try:
+        pgid = os.getpgid(pid)
+        if pgid == pid:
+            os.killpg(pgid, sig)
+        else:
+            os.kill(pid, sig)
+        return
+    except (ProcessLookupError, OSError):
+        pass
+
+    # Process may already be dead; try killpg with pid as pgid (valid
+    # for session leaders even after the leader has exited, as the
+    # process group persists until all members exit).
+    try:
+        os.killpg(pid, sig)
+    except (ProcessLookupError, OSError):
+        pass
+
+
 def _ensure_process_dead(pid: int | None, grace_seconds: float = 2.0) -> None:
     """Wait for the process to exit gracefully, then force-kill it if necessary."""
     if pid is None:
@@ -50,19 +91,10 @@ def _ensure_process_dead(pid: int | None, grace_seconds: float = 2.0) -> None:
             break
         time.sleep(0.1)
 
-    # If still alive (not a zombie), escalate to force kill
+    # If still alive (not a zombie), escalate to force kill the entire
+    # process group (kills Chrome child processes on FreeBSD — issue #90).
     if _process_alive(pid):
-        try:
-            if utils.PLATFORM_VERSION == "nt":
-                subprocess.run(  # nosec
-                    ["taskkill", "/F", "/PID", str(pid)],
-                    check=False,
-                    capture_output=True,
-                )
-            else:
-                os.kill(pid, signal.SIGKILL)
-        except Exception:  # nosec B110
-            pass
+        _kill_process_tree(pid, signal.SIGKILL)
 
     # Reap the zombie if we are the parent
     try:

--- a/src/flaresolverr/undetected_chromedriver/__init__.py
+++ b/src/flaresolverr/undetected_chromedriver/__init__.py
@@ -65,6 +65,32 @@ logger = logging.getLogger("uc")
 logger.setLevel(logging.getLogger().getEffectiveLevel())
 
 
+def _kill_process_group(pid: int, sig: int) -> None:
+    """Kill a process and all children in its process group.
+
+    Chrome is started with ``start_new_session=True`` (setsid), so its
+    PGID == PID.  Killing the entire group is critical on FreeBSD where
+    Chrome child processes don't auto-die when the parent is killed —
+    FreeBSD lacks ``prctl(PR_SET_PDEATHSIG)`` — so they would otherwise
+    become orphaned and leak (issue #90).
+    """
+    try:
+        pgid = os.getpgid(pid)
+        if pgid == pid:
+            os.killpg(pgid, sig)
+        else:
+            os.kill(pid, sig)
+        return
+    except (ProcessLookupError, OSError):
+        pass
+    # Process may already be dead; try killpg with pid as pgid (valid
+    # for session leaders even after the leader has exited).
+    try:
+        os.killpg(pid, sig)
+    except (ProcessLookupError, OSError):
+        pass
+
+
 class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
     """
 
@@ -772,7 +798,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
         except AttributeError:
             pass
         try:
-            os.kill(self.browser_pid, 15)
+            _kill_process_group(self.browser_pid, 15)
             logger.debug("gracefully closed browser")
         except Exception as e:  # noqa
             pass
@@ -789,10 +815,11 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
                         break
                     time.sleep(0.1)
                 else:
-                    # Still alive after 3s: escalate to SIGKILL
+                    # Still alive after 3s: escalate to SIGKILL the
+                    # entire process group (issue #90).
                     try:
-                        os.kill(self.browser_pid, 9)
-                        logger.debug("sent SIGKILL to browser")
+                        _kill_process_group(self.browser_pid, 9)
+                        logger.debug("sent SIGKILL to browser process group")
                     except (ProcessLookupError, OSError):
                         pass
                     # Brief wait after SIGKILL

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -292,16 +292,78 @@ def test_process_alive_detects_missing_process() -> None:
 def test_ensure_process_dead_waits_then_force_kills(monkeypatch) -> None:
     killed = {"sigkill": False}
 
-    def fake_kill(pid, sig):
+    def fake_kill_process_tree(pid, sig):
         if sig == signal.SIGKILL:
             killed["sigkill"] = True
 
     monkeypatch.setattr(sessions, "_process_alive", lambda pid: not killed["sigkill"])
-    monkeypatch.setattr(os, "kill", fake_kill)
+    monkeypatch.setattr(sessions, "_kill_process_tree", fake_kill_process_tree)
     monkeypatch.setattr(time, "sleep", lambda s: None)
 
     sessions._ensure_process_dead(12345, grace_seconds=0.5)
     assert killed["sigkill"] is True
+
+
+def test_kill_process_tree_uses_killpg_for_session_leader(monkeypatch) -> None:
+    """When PGID == PID (session leader), kill the entire process group."""
+    killed = {"pgid": None, "sig": None}
+
+    def fake_getpgid(pid):
+        return pid  # session leader: PGID == PID
+
+    def fake_killpg(pgid, sig):
+        killed["pgid"] = pgid
+        killed["sig"] = sig
+
+    monkeypatch.setattr(sessions.utils, "PLATFORM_VERSION", "posix")
+    monkeypatch.setattr(os, "getpgid", fake_getpgid)
+    monkeypatch.setattr(os, "killpg", fake_killpg)
+    monkeypatch.setattr(os, "kill", lambda pid, sig: pytest.fail("should use killpg, not kill"))
+
+    sessions._kill_process_tree(999, signal.SIGTERM)
+    assert killed["pgid"] == 999
+    assert killed["sig"] == signal.SIGTERM
+
+
+def test_kill_process_tree_uses_kill_for_non_leader(monkeypatch) -> None:
+    """When PGID != PID (not a session leader), kill only the single process."""
+    killed = {"pid": None, "sig": None}
+
+    def fake_getpgid(pid):
+        return 1  # not a session leader
+
+    def fake_kill(pid, sig):
+        killed["pid"] = pid
+        killed["sig"] = sig
+
+    monkeypatch.setattr(sessions.utils, "PLATFORM_VERSION", "posix")
+    monkeypatch.setattr(os, "getpgid", fake_getpgid)
+    monkeypatch.setattr(os, "killpg", lambda pgid, sig: pytest.fail("should use kill, not killpg"))
+    monkeypatch.setattr(os, "kill", fake_kill)
+
+    sessions._kill_process_tree(999, signal.SIGKILL)
+    assert killed["pid"] == 999
+    assert killed["sig"] == signal.SIGKILL
+
+
+def test_kill_process_tree_falls_back_to_killpg_on_error(monkeypatch) -> None:
+    """If os.getpgid fails (process gone), fall back to killpg with pid as pgid."""
+    killed = {"pgid": None, "sig": None}
+
+    def fake_getpgid(pid):
+        raise ProcessLookupError("no such process")
+
+    def fake_killpg(pgid, sig):
+        killed["pgid"] = pgid
+        killed["sig"] = sig
+
+    monkeypatch.setattr(sessions.utils, "PLATFORM_VERSION", "posix")
+    monkeypatch.setattr(os, "getpgid", fake_getpgid)
+    monkeypatch.setattr(os, "killpg", fake_killpg)
+
+    sessions._kill_process_tree(999, signal.SIGKILL)
+    assert killed["pgid"] == 999
+    assert killed["sig"] == signal.SIGKILL
 
 
 def test_destroy_verifies_browser_pid_dead(monkeypatch) -> None:


### PR DESCRIPTION
## Fix for #90

### Problem
Chrome processes accumulate and stay in memory after `sessions.destroy` on FreeBSD. The `sessions.destroy` and `sessions.cleanup` commands return `200 OK` but Chrome child processes persist.

### Root Cause
Chrome is started via `start_detached()` with `start_new_session=True` (`setsid()`), making Chrome a **session/process group leader**. Chrome then spawns child processes (renderer, GPU, etc.).

- On **Linux**: Chrome uses `prctl(PR_SET_PDEATHSIG, SIGKILL)` so children auto-die when the parent is killed
- On **FreeBSD**: `prctl` does not exist, so Chrome's child processes become **orphaned** and keep running indefinitely

The old code only killed the single `browser_pid` (the Chrome parent), leaving all child processes alive on FreeBSD.

### Fix
Kill the **entire process group** instead of just the browser parent PID. Since Chrome was started with `setsid()`, its PGID == PID, so `os.killpg(browser_pid, signal)` kills all Chrome processes in that group.

### Changes
- **`src/flaresolverr/sessions.py`**: Added `_kill_process_tree()` helper that uses `os.killpg()` when the process is a session leader (PGID == PID), with fallback. Updated `_ensure_process_dead()` to use it for SIGKILL escalation.
- **`src/flaresolverr/undetected_chromedriver/__init__.py`**: Added `_kill_process_group()` helper. Updated `quit()` to use it for both SIGTERM and SIGKILL escalation instead of `os.kill(browser_pid, ...)`.
- **`tests/unit/test_sessions.py`**: Updated `test_ensure_process_dead_waits_then_force_kills`, added 3 new tests for process group kill behavior (session leader uses `killpg`, non-leader uses `kill`, fallback to `killpg` on `ProcessLookupError`).

### Testing
All 403 unit tests pass.

Fixes #90