### PR TITLE
Port selected fixes from FlareSolverr/FlareSolverr#1755

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - AGENT_CHECK_HOST=${AGENT_CHECK_HOST:-127.0.0.1}
       - TZ=Europe/London
     ports:
-      - "${PORT:-8191}:8191"
+      - "${PORT_BIND:-127.0.0.1}:${PORT:-8191}:8191"
     volumes:
       - /var/lib/flaresolver:/config
     restart: unless-stopped

--- a/src/flaresolverr/flaresolverr_service.py
+++ b/src/flaresolverr/flaresolverr_service.py
@@ -12,7 +12,7 @@ import time
 from datetime import timedelta
 from html import escape
 from typing import Any, cast
-from urllib.parse import quote, unquote, urlparse
+from urllib.parse import parse_qsl, quote, urlparse
 
 from func_timeout import FunctionTimedOut, func_timeout
 from selenium.common import UnexpectedAlertPresentException
@@ -1492,26 +1492,12 @@ def _post_request(req: V1RequestBase, driver: WebDriver) -> None:
     if req.postDataRaw is not None:
         _post_request_raw(req, driver)
         return
-    post_form = f'<form id="hackForm" action="{escape(req.url)}" method="POST">'
-    query_string = req.postData if req.postData and req.postData[0] != "?" else req.postData[1:] if req.postData else ""
-    pairs = query_string.split("&")
-    for pair in pairs:
-        parts = pair.split("=", 1)
-        # noinspection PyBroadException
-        try:
-            name = unquote(parts[0])
-        except Exception:  # noqa: BLE001
-            name = parts[0]
+    post_form = f'<form id="hackForm" action="{escape(req.url, quote=True)}" method="POST">'
+    query_string = req.postData[1:] if req.postData.startswith("?") else req.postData
+    for name, value in parse_qsl(query_string, keep_blank_values=True):
         if name == "submit":
             continue
-        # noinspection PyBroadException
-        try:
-            value = unquote(parts[1]) if len(parts) > 1 else ""
-        except Exception:  # noqa: BLE001
-            value = parts[1] if len(parts) > 1 else ""
-        # Protection of " character, for syntax
-        value = value.replace('"', "&quot;")
-        post_form += f'<input type="text" name="{escape(quote(name))}" value="{escape(quote(value))}"><br>'
+        post_form += f'<input type="text" name="{escape(name, quote=True)}" value="{escape(value, quote=True)}"><br>'
     post_form += "</form>"
     html_content = f"""
         <!DOCTYPE html>
@@ -1521,5 +1507,4 @@ def _post_request(req: V1RequestBase, driver: WebDriver) -> None:
             <script>document.getElementById('hackForm').submit();</script>
         </body>
         </html>"""
-    # Use percent-encoded data: URI to avoid fragment/encoding issues
-    driver.get(f"data:text/html;charset=utf-8,{quote(html_content)}")
+    driver.get("data:text/html;charset=utf-8," + quote(html_content, safe=""))


### PR DESCRIPTION
## Summary

This PR cherry-picks the two low-risk fixes from [FlareSolverr/FlareSolverr#1755](https://github.com/FlareSolverr/FlareSolverr/pull/1755) that are relevant and not already present in this fork.

## Changes

- **`src/flaresolverr/flaresolverr_service.py`**: use `urllib.parse.parse_qsl(..., keep_blank_values=True)` for `request.post` form generation, escape the form action and input names/values with `quote=True`, and percent-encode the data-URI payload with `safe=""`. This correctly handles `+` as space, preserves blank fields, and avoids manual `unquote`/`split` bugs.
- **`docker-compose.yml`**: bind the published port to `127.0.0.1` by default and allow overriding the bind address via `PORT_BIND`.

## Not ported

The other three fixes from the upstream PR are already covered by the fork's existing code:

- Proxy credential serialization: this fork uses a static manifest-v3 proxy extension and `json.dumps()` at runtime.
- Session storage race protection: `SessionsStorage` already uses an `RLock` and per-session locks.
- Sensitive API log redaction: the controller already redacts proxy credentials; a broader redactor can be added later if desired.

## Test plan

- `git diff --check` passes.
- `uv run python -m compileall src/flaresolverr` succeeds.
- `PYTHONDONTWRITEBYTECODE=1 uv run python -m pytest tests/unit/test_post_raw.py -q` passes (12/12).